### PR TITLE
Model fixed table colspan constraints

### DIFF
--- a/moli-layout/src/table.rs
+++ b/moli-layout/src/table.rs
@@ -26,7 +26,10 @@ mod columns;
 
 pub(crate) use collapsed_borders::CollapsedTableBorders;
 use collapsed_borders::{prepare_collapsed_table_borders, set_collapsed_border_geometry};
-use columns::{TableColumnConstraint, distribute_fixed_columns, fixed_grid_min_inline_size};
+use columns::{
+    TableCellInlineConstraint, TableCellSpanConstraint, TableColumnConstraint,
+    distribute_fixed_cell_spans, distribute_fixed_columns, fixed_grid_min_inline_size,
+};
 
 #[derive(Clone)]
 struct TableCell {
@@ -52,6 +55,66 @@ struct TableColumn {
     group: Option<LayoutBoxId>,
     start: usize,
     span: usize,
+}
+
+/// Direct table children grouped by their CSS table role.
+///
+/// A table's first header and footer groups have a visual position independent
+/// of tree order. Keeping this grouping as a first-class input ensures row
+/// placement, first-row column constraints, and structural box geometry all
+/// consume the same section order.
+#[derive(Default)]
+struct TableGroupedChildren {
+    captions: Vec<LayoutBoxId>,
+    columns: Vec<LayoutBoxId>,
+    header: Option<LayoutBoxId>,
+    bodies: Vec<LayoutBoxId>,
+    footer: Option<LayoutBoxId>,
+}
+
+impl TableGroupedChildren {
+    fn collect<N>(world: &LayoutWorld<N>, root: LayoutBoxId) -> Self
+    where
+        N: Copy + Debug + Eq + Hash,
+    {
+        let mut grouped = Self::default();
+        for child in world.boxes[root.index()].children.iter().copied() {
+            match world.boxes[child.index()].kind {
+                LayoutBoxKind::TableCaption => grouped.captions.push(child),
+                LayoutBoxKind::TableColumnGroup | LayoutBoxKind::TableColumn => {
+                    grouped.columns.push(child)
+                }
+                LayoutBoxKind::TableHeaderGroup => {
+                    if grouped.header.is_none() {
+                        grouped.header = Some(child);
+                    } else {
+                        grouped.bodies.push(child);
+                    }
+                }
+                LayoutBoxKind::TableRowGroup
+                | LayoutBoxKind::AnonymousTableRowGroup
+                | LayoutBoxKind::TableRow
+                | LayoutBoxKind::AnonymousTableRow => grouped.bodies.push(child),
+                LayoutBoxKind::TableFooterGroup => {
+                    if grouped.footer.is_none() {
+                        grouped.footer = Some(child);
+                    } else {
+                        grouped.bodies.push(child);
+                    }
+                }
+                _ => {}
+            }
+        }
+        grouped
+    }
+
+    fn sections(&self) -> impl Iterator<Item = LayoutBoxId> + '_ {
+        self.header
+            .iter()
+            .copied()
+            .chain(self.bodies.iter().copied())
+            .chain(self.footer.iter().copied())
+    }
 }
 
 struct TableContext {
@@ -234,14 +297,20 @@ where
     style.grid_auto_columns.clear();
     style.grid_auto_rows.clear();
 
+    let grouped_children = TableGroupedChildren::collect(world, root);
     let mut cells = Vec::new();
     let mut rows = Vec::new();
     let mut columns = Vec::new();
-    let mut captions = Vec::new();
     let mut max_columns = 0usize;
     let mut column_tracks = Vec::new();
-    collect_columns(world, root, None, &mut columns, &mut column_tracks);
-    collect_rows(world, root, None, &mut rows, &mut cells);
+    let mut cell_span_constraints = Vec::new();
+    let fixed_layout = root_style.table_layout_is_fixed();
+    for column in grouped_children.columns.iter().copied() {
+        collect_columns(world, column, None, &mut columns, &mut column_tracks);
+    }
+    for section in grouped_children.sections() {
+        collect_rows(world, section, None, &mut rows, &mut cells);
+    }
     place_table_cells(&mut cells, &rows, &mut max_columns);
     for cell in &mut cells {
         cell.style.grid_column = Line {
@@ -252,15 +321,19 @@ where
             start: style_helpers::line((cell.row + 1).min(i16::MAX as usize) as i16),
             end: style_helpers::span(cell.row_span as u16),
         };
-        if cell.row == 0 && cell.column_span == 1 {
-            if cell.column >= column_tracks.len() {
-                column_tracks.resize(cell.column + 1, TableColumnConstraint::auto());
-            }
-            // An explicit <col>/<colgroup> width wins over the first-row
-            // cell width in the fixed table algorithm.
-            if column_tracks[cell.column].is_auto() {
-                column_tracks[cell.column] =
-                    table_cell_width_track(&cell.style, root_style.table_layout_is_fixed());
+        if cell.row == 0 {
+            let inline_constraint = table_cell_inline_constraint(&cell.style, fixed_layout);
+            if cell.column_span == 1 {
+                if cell.column >= column_tracks.len() {
+                    column_tracks.resize(cell.column + 1, TableColumnConstraint::auto());
+                }
+                column_tracks[cell.column].encompass_first_row_cell(inline_constraint);
+            } else if fixed_layout {
+                cell_span_constraints.push(TableCellSpanConstraint {
+                    start_column: cell.column,
+                    span: cell.column_span,
+                    cell: inline_constraint,
+                });
             }
         }
         cell.style.size.width = Dimension::auto();
@@ -272,10 +345,15 @@ where
         }
         cell.style.size.height = Dimension::auto();
     }
-    collect_captions(world, root, &mut captions);
     max_columns = max_columns.max(column_tracks.len()).max(1);
     column_tracks.resize(max_columns, TableColumnConstraint::auto());
-    let fixed_layout = root_style.table_layout_is_fixed();
+    if fixed_layout {
+        distribute_fixed_cell_spans(
+            &mut column_tracks,
+            &mut cell_span_constraints,
+            spacing.width,
+        );
+    }
     style.grid_template_columns = column_tracks
         .iter()
         .copied()
@@ -306,7 +384,7 @@ where
         cells,
         rows,
         columns,
-        captions,
+        captions: grouped_children.captions,
         detailed: None,
         collapsed_borders: collapsed,
         column_count: max_columns,
@@ -417,17 +495,6 @@ impl TableContext {
     }
 }
 
-fn collect_captions<N>(world: &LayoutWorld<N>, root: LayoutBoxId, output: &mut Vec<LayoutBoxId>)
-where
-    N: Copy + Debug + Eq + Hash,
-{
-    for child in world.boxes[root.index()].children.iter().copied() {
-        if world.boxes[child.index()].kind == LayoutBoxKind::TableCaption {
-            output.push(child);
-        }
-    }
-}
-
 fn collect_columns<N>(
     world: &LayoutWorld<N>,
     current: LayoutBoxId,
@@ -437,37 +504,37 @@ fn collect_columns<N>(
 ) where
     N: Copy + Debug + Eq + Hash,
 {
-    for child in world.boxes[current.index()].children.iter().copied() {
-        match world.boxes[child.index()].kind {
-            LayoutBoxKind::TableColumnGroup => {
-                let before = tracks.len();
-                collect_columns(world, child, Some(child), columns, tracks);
-                if tracks.len() == before {
-                    let span = table_data(world, child).span.max(1) as usize;
-                    let track = dimension_track(world.boxes[child.index()].style.taffy.size.width);
-                    tracks.extend(std::iter::repeat_n(track, span));
-                    columns.push(TableColumn {
-                        id: child,
-                        group: None,
-                        start: before,
-                        span,
-                    });
-                }
+    match world.boxes[current.index()].kind {
+        LayoutBoxKind::TableColumnGroup => {
+            let before = tracks.len();
+            for child in world.boxes[current.index()].children.iter().copied() {
+                collect_columns(world, child, Some(current), columns, tracks);
             }
-            LayoutBoxKind::TableColumn => {
-                let span = table_data(world, child).span.max(1) as usize;
-                let start = tracks.len();
-                let track = dimension_track(world.boxes[child.index()].style.taffy.size.width);
+            if tracks.len() == before {
+                let span = table_data(world, current).span.max(1) as usize;
+                let track = dimension_track(world.boxes[current.index()].style.taffy.size.width);
                 tracks.extend(std::iter::repeat_n(track, span));
                 columns.push(TableColumn {
-                    id: child,
-                    group,
-                    start,
+                    id: current,
+                    group: None,
+                    start: before,
                     span,
                 });
             }
-            _ => {}
         }
+        LayoutBoxKind::TableColumn => {
+            let span = table_data(world, current).span.max(1) as usize;
+            let start = tracks.len();
+            let track = dimension_track(world.boxes[current.index()].style.taffy.size.width);
+            tracks.extend(std::iter::repeat_n(track, span));
+            columns.push(TableColumn {
+                id: current,
+                group,
+                start,
+                span,
+            });
+        }
+        _ => {}
     }
 }
 
@@ -480,48 +547,48 @@ fn collect_rows<N>(
 ) where
     N: Copy + Debug + Eq + Hash,
 {
-    for child in world.boxes[current.index()].children.iter().copied() {
-        match world.boxes[child.index()].kind {
-            LayoutBoxKind::TableRowGroup
-            | LayoutBoxKind::TableHeaderGroup
-            | LayoutBoxKind::TableFooterGroup
-            | LayoutBoxKind::AnonymousTableRowGroup => {
-                collect_rows(world, child, Some(child), rows, cells)
+    match world.boxes[current.index()].kind {
+        LayoutBoxKind::TableRowGroup
+        | LayoutBoxKind::TableHeaderGroup
+        | LayoutBoxKind::TableFooterGroup
+        | LayoutBoxKind::AnonymousTableRowGroup => {
+            for child in world.boxes[current.index()].children.iter().copied() {
+                collect_rows(world, child, Some(current), rows, cells);
             }
-            LayoutBoxKind::TableRow | LayoutBoxKind::AnonymousTableRow => {
-                let row_index = rows.len();
-                rows.push(TableRow {
-                    id: child,
-                    group,
-                    index: row_index,
-                    track: minimum_dimension_track(
-                        world.boxes[child.index()].style.taffy.size.height,
-                    ),
-                });
-                for cell in world.boxes[child.index()].children.iter().copied() {
-                    if !matches!(
-                        world.boxes[cell.index()].kind,
-                        LayoutBoxKind::TableCell | LayoutBoxKind::AnonymousTableCell
-                    ) {
-                        continue;
-                    }
-                    let data = table_data(world, cell);
-                    let column_span = usize::from(data.column_span.max(1));
-                    let row_span = usize::from(data.row_span.max(1));
-                    let mut cell_style = world.boxes[cell.index()].style.taffy.clone();
-                    cell_style.margin = Rect::ZERO.map(style_helpers::length);
-                    cells.push(TableCell {
-                        id: cell,
-                        style: cell_style,
-                        row: row_index,
-                        column: 0,
-                        row_span,
-                        column_span,
-                    });
-                }
-            }
-            _ => {}
         }
+        LayoutBoxKind::TableRow | LayoutBoxKind::AnonymousTableRow => {
+            let row_index = rows.len();
+            rows.push(TableRow {
+                id: current,
+                group,
+                index: row_index,
+                track: minimum_dimension_track(
+                    world.boxes[current.index()].style.taffy.size.height,
+                ),
+            });
+            for cell in world.boxes[current.index()].children.iter().copied() {
+                if !matches!(
+                    world.boxes[cell.index()].kind,
+                    LayoutBoxKind::TableCell | LayoutBoxKind::AnonymousTableCell
+                ) {
+                    continue;
+                }
+                let data = table_data(world, cell);
+                let column_span = usize::from(data.column_span.max(1));
+                let row_span = usize::from(data.row_span.max(1));
+                let mut cell_style = world.boxes[cell.index()].style.taffy.clone();
+                cell_style.margin = Rect::ZERO.map(style_helpers::length);
+                cells.push(TableCell {
+                    id: cell,
+                    style: cell_style,
+                    row: row_index,
+                    column: 0,
+                    row_span,
+                    column_span,
+                });
+            }
+        }
+        _ => {}
     }
 }
 
@@ -584,7 +651,7 @@ fn dimension_track(dimension: Dimension) -> TableColumnConstraint {
     match dimension.tag() {
         taffy::CompactLength::LENGTH_TAG => TableColumnConstraint::length(dimension.value()),
         taffy::CompactLength::PERCENT_TAG => TableColumnConstraint::percent(dimension.value(), 0.0),
-        _ => TableColumnConstraint::auto(),
+        _ => TableColumnConstraint::explicit_auto(),
     }
 }
 
@@ -602,7 +669,7 @@ fn minimum_dimension_track(dimension: Dimension) -> taffy::TrackSizingFunction {
     }
 }
 
-fn table_cell_width_track(style: &Style<Atom>, fixed: bool) -> TableColumnConstraint {
+fn table_cell_inline_constraint(style: &Style<Atom>, fixed: bool) -> TableCellInlineConstraint {
     match style.size.width.tag() {
         taffy::CompactLength::LENGTH_TAG => {
             let padding = style
@@ -615,7 +682,7 @@ fn table_cell_width_track(style: &Style<Atom>, fixed: bool) -> TableColumnConstr
             } else {
                 style.size.width.value().max(border_padding)
             };
-            TableColumnConstraint::length(outer_width)
+            TableCellInlineConstraint::length(outer_width)
         }
         taffy::CompactLength::PERCENT_TAG if fixed => {
             let border_padding = if style.box_sizing == taffy::BoxSizing::ContentBox {
@@ -627,9 +694,9 @@ fn table_cell_width_track(style: &Style<Atom>, fixed: bool) -> TableColumnConstr
             } else {
                 0.0
             };
-            TableColumnConstraint::percent(style.size.width.value(), border_padding)
+            TableCellInlineConstraint::percent(style.size.width.value(), border_padding)
         }
-        _ => TableColumnConstraint::auto(),
+        _ => TableCellInlineConstraint::auto(),
     }
 }
 

--- a/moli-layout/src/table/columns.rs
+++ b/moli-layout/src/table/columns.rs
@@ -8,7 +8,12 @@ use taffy::{TrackSizingFunction, style_helpers};
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub(super) struct TableColumnConstraint {
     /// Intrinsic floor accumulated from cells and column boxes.
-    pub(super) min_inline_size: f32,
+    ///
+    /// An explicit column starts at `Some(0)`; `None` means an implicit
+    /// column has not received a cell constraint yet. Blink preserves this
+    /// distinction because colspan min/max contributions are filled
+    /// independently.
+    pub(super) min_inline_size: Option<f32>,
     /// Maximum/fixed measure. `is_constrained` distinguishes a declared width
     /// from an intrinsic maximum once automatic table sizing is implemented.
     pub(super) max_inline_size: Option<f32>,
@@ -17,11 +22,25 @@ pub(super) struct TableColumnConstraint {
     pub(super) is_constrained: bool,
 }
 
-impl TableColumnConstraint {
+/// Inline-size information contributed by a table cell.
+///
+/// Keeping cell constraints separate from column constraints is important for
+/// wide cells: a `colspan` cell contributes one measure over a range and must
+/// not masquerade as a width authored on any individual column.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(super) struct TableCellInlineConstraint {
+    pub(super) min_inline_size: f32,
+    pub(super) max_inline_size: f32,
+    pub(super) percent: Option<f32>,
+    pub(super) percent_border_padding: f32,
+    pub(super) is_constrained: bool,
+}
+
+impl TableCellInlineConstraint {
     pub(super) const fn auto() -> Self {
         Self {
             min_inline_size: 0.0,
-            max_inline_size: None,
+            max_inline_size: 0.0,
             percent: None,
             percent_border_padding: 0.0,
             is_constrained: false,
@@ -30,6 +49,51 @@ impl TableColumnConstraint {
 
     pub(super) fn length(value: f32) -> Self {
         Self {
+            max_inline_size: value.max(0.0),
+            is_constrained: true,
+            ..Self::auto()
+        }
+    }
+
+    pub(super) fn percent(ratio: f32, border_padding: f32) -> Self {
+        Self {
+            max_inline_size: border_padding.max(0.0),
+            percent: Some(ratio.max(0.0)),
+            percent_border_padding: border_padding.max(0.0),
+            ..Self::auto()
+        }
+    }
+}
+
+/// A cell constraint that covers more than one column.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct TableCellSpanConstraint {
+    pub(super) start_column: usize,
+    pub(super) span: usize,
+    pub(super) cell: TableCellInlineConstraint,
+}
+
+impl TableColumnConstraint {
+    pub(super) const fn auto() -> Self {
+        Self {
+            min_inline_size: None,
+            max_inline_size: None,
+            percent: None,
+            percent_border_padding: 0.0,
+            is_constrained: false,
+        }
+    }
+
+    pub(super) const fn explicit_auto() -> Self {
+        Self {
+            min_inline_size: Some(0.0),
+            ..Self::auto()
+        }
+    }
+
+    pub(super) fn length(value: f32) -> Self {
+        Self {
+            min_inline_size: Some(0.0),
             max_inline_size: Some(value.max(0.0)),
             is_constrained: true,
             ..Self::auto()
@@ -38,14 +102,35 @@ impl TableColumnConstraint {
 
     pub(super) fn percent(ratio: f32, border_padding: f32) -> Self {
         Self {
+            min_inline_size: Some(0.0),
             percent: Some(ratio.max(0.0)),
             percent_border_padding: border_padding.max(0.0),
             ..Self::auto()
         }
     }
 
-    pub(super) fn is_auto(self) -> bool {
-        self.max_inline_size.is_none() && self.percent.is_none()
+    /// Apply a single-column first-row cell while preserving the precedence of
+    /// an authored `<col>`/`<colgroup>` measure.
+    pub(super) fn encompass_first_row_cell(&mut self, cell: TableCellInlineConstraint) {
+        if self.is_constrained {
+            return;
+        }
+
+        self.min_inline_size = Some(
+            self.min_inline_size
+                .unwrap_or(cell.min_inline_size)
+                .max(cell.min_inline_size),
+        );
+        self.max_inline_size = Some(
+            self.max_inline_size
+                .unwrap_or(0.0)
+                .max(cell.max_inline_size),
+        );
+        if cell.percent > self.percent {
+            self.percent = cell.percent;
+            self.percent_border_padding = cell.percent_border_padding;
+        }
+        self.is_constrained |= cell.is_constrained;
     }
 
     /// Track used while the table has no definite assignable inline size, or
@@ -64,6 +149,7 @@ impl TableColumnConstraint {
     fn resolved_percent(self, assignable_inline_size: f32) -> Option<f32> {
         self.percent.map(|ratio| {
             self.min_inline_size
+                .unwrap_or(0.0)
                 .max(ratio * assignable_inline_size + self.percent_border_padding)
         })
     }
@@ -82,10 +168,11 @@ impl TableColumnConstraint {
     }
 
     fn fixed_grid_min_inline_size(self) -> f32 {
+        let min_inline_size = self.min_inline_size.unwrap_or(0.0);
         if let Some(fixed) = self.fixed_inline_size() {
-            self.min_inline_size.max(fixed)
+            min_inline_size.max(fixed)
         } else {
-            self.min_inline_size.max(self.percent_border_padding)
+            min_inline_size.max(self.percent_border_padding)
         }
     }
 }
@@ -101,6 +188,76 @@ pub(super) fn fixed_grid_min_inline_size(constraints: &[TableColumnConstraint]) 
         .copied()
         .map(TableColumnConstraint::fixed_grid_min_inline_size)
         .sum()
+}
+
+/// Project first-row wide-cell constraints onto fixed-layout columns.
+///
+/// This mirrors Blink's `DistributeColspanCellToColumnsFixed`: shorter spans
+/// are applied first, inner border spacing is excluded from the cell measure,
+/// existing column measures retain priority, and percentage constraints are
+/// copied only to unconstrained columns. The final fixed-column allocator then
+/// operates solely on column constraints.
+pub(super) fn distribute_fixed_cell_spans(
+    column_constraints: &mut [TableColumnConstraint],
+    cell_spans: &mut [TableCellSpanConstraint],
+    inline_border_spacing: f32,
+) {
+    cell_spans.sort_by_key(|constraint| (constraint.span, constraint.start_column));
+
+    for constraint in cell_spans {
+        let Some(column_span) = column_constraints.get_mut(constraint.start_column..) else {
+            continue;
+        };
+        let effective_span = constraint.span.min(column_span.len());
+        if effective_span == 0 {
+            continue;
+        }
+        let column_span = &mut column_span[..effective_span];
+        let inner_spacing =
+            inline_border_spacing.max(0.0) * effective_span.saturating_sub(1) as f32;
+        let min_inline_size = if constraint.cell.is_constrained {
+            (constraint.cell.min_inline_size - inner_spacing).max(0.0)
+        } else {
+            0.0
+        };
+        let max_inline_size = (constraint.cell.max_inline_size - inner_spacing).max(0.0);
+        let min_share = min_inline_size / effective_span as f32;
+        let max_share = max_inline_size / effective_span as f32;
+        let percent_share = constraint
+            .cell
+            .percent
+            .map(|percent| percent / effective_span as f32);
+
+        for (index, column) in column_span.iter_mut().enumerate() {
+            let is_last = index + 1 == effective_span;
+            let distributed_min = if is_last {
+                min_inline_size - min_share * index as f32
+            } else {
+                min_share
+            };
+            let distributed_max = if is_last {
+                max_inline_size - max_share * index as f32
+            } else {
+                max_share
+            };
+            if column.min_inline_size.is_none() {
+                column.min_inline_size = Some(distributed_min);
+                column.is_constrained |= constraint.cell.is_constrained;
+            }
+            if column.max_inline_size.is_none() {
+                column.max_inline_size =
+                    Some(distributed_max.max(column.min_inline_size.unwrap_or(0.0)));
+                column.is_constrained |= constraint.cell.is_constrained;
+            }
+            if column.percent.is_none() && !column.is_constrained {
+                column.percent = percent_share;
+                // A wide percentage cell contributes its percentage, but its
+                // border/padding belongs to the spanning cell rather than any
+                // one of the columns.
+                column.percent_border_padding = 0.0;
+            }
+        }
+    }
 }
 
 /// Synchronize fixed-table column constraints with the assignable inline size.
@@ -250,6 +407,108 @@ mod tests {
                 "column {index}: expected {expected}, got {actual}; all={actual_sizes:?}",
             );
         }
+    }
+
+    #[test]
+    fn fixed_cell_spans_apply_shorter_ranges_before_wider_ranges() {
+        let mut columns = [TableColumnConstraint::auto(); 3];
+        let mut spans = [
+            TableCellSpanConstraint {
+                start_column: 0,
+                span: 3,
+                cell: TableCellInlineConstraint::length(150.0),
+            },
+            TableCellSpanConstraint {
+                start_column: 0,
+                span: 2,
+                cell: TableCellInlineConstraint::length(80.0),
+            },
+        ];
+
+        distribute_fixed_cell_spans(&mut columns, &mut spans, 0.0);
+
+        assert_eq!(columns[0].max_inline_size, Some(40.0));
+        assert_eq!(columns[1].max_inline_size, Some(40.0));
+        assert_eq!(columns[2].max_inline_size, Some(50.0));
+    }
+
+    #[test]
+    fn fixed_cell_spans_preserve_columns_and_exclude_internal_spacing() {
+        let mut columns = [
+            TableColumnConstraint::length(80.0),
+            TableColumnConstraint::auto(),
+            TableColumnConstraint::auto(),
+        ];
+        let mut spans = [TableCellSpanConstraint {
+            start_column: 0,
+            span: 2,
+            cell: TableCellInlineConstraint::length(210.0),
+        }];
+
+        distribute_fixed_cell_spans(&mut columns, &mut spans, 10.0);
+
+        assert_eq!(columns[0].max_inline_size, Some(80.0));
+        assert_eq!(columns[1].max_inline_size, Some(100.0));
+        assert_sizes(
+            &distribute_fixed_columns(300.0, &columns),
+            &[80.0, 100.0, 120.0],
+        );
+    }
+
+    #[test]
+    fn fixed_cell_spans_divide_percent_without_cell_border_padding() {
+        let mut columns = [TableColumnConstraint::auto(); 3];
+        let mut spans = [TableCellSpanConstraint {
+            start_column: 0,
+            span: 2,
+            cell: TableCellInlineConstraint::percent(0.4, 20.0),
+        }];
+
+        distribute_fixed_cell_spans(&mut columns, &mut spans, 0.0);
+
+        assert_eq!(columns[0].percent, Some(0.2));
+        assert_eq!(columns[1].percent, Some(0.2));
+        assert_eq!(columns[0].percent_border_padding, 0.0);
+        assert_eq!(columns[1].percent_border_padding, 0.0);
+        assert_sizes(
+            &distribute_fixed_columns(500.0, &columns),
+            &[100.0, 100.0, 300.0],
+        );
+    }
+
+    #[test]
+    fn fixed_cell_spans_fill_missing_min_and_max_constraints_independently() {
+        let mut columns = [
+            TableColumnConstraint::explicit_auto(),
+            TableColumnConstraint::percent(0.5, 0.0),
+            TableColumnConstraint {
+                max_inline_size: Some(70.0),
+                ..TableColumnConstraint::auto()
+            },
+            TableColumnConstraint::auto(),
+        ];
+        let mut spans = [TableCellSpanConstraint {
+            start_column: 0,
+            span: 4,
+            cell: TableCellInlineConstraint {
+                min_inline_size: 80.0,
+                max_inline_size: 160.0,
+                percent: None,
+                percent_border_padding: 0.0,
+                is_constrained: true,
+            },
+        }];
+
+        distribute_fixed_cell_spans(&mut columns, &mut spans, 0.0);
+
+        assert_eq!(columns[0].min_inline_size, Some(0.0));
+        assert_eq!(columns[1].min_inline_size, Some(0.0));
+        assert_eq!(columns[2].min_inline_size, Some(20.0));
+        assert_eq!(columns[3].min_inline_size, Some(20.0));
+        assert_eq!(columns[0].max_inline_size, Some(40.0));
+        assert_eq!(columns[1].max_inline_size, Some(40.0));
+        assert_eq!(columns[2].max_inline_size, Some(70.0));
+        assert_eq!(columns[3].max_inline_size, Some(40.0));
     }
 
     #[test]

--- a/moli-layout/tests/phase4_layout_contract.rs
+++ b/moli-layout/tests/phase4_layout_contract.rs
@@ -317,6 +317,110 @@ fn table_caption_tracks_rows_cells_and_common_spans_share_one_wrapper_geometry()
 }
 
 #[test]
+fn table_sections_use_visual_header_body_footer_order() {
+    use LayoutElementCategory::Table;
+    use LayoutTableRole::{BodyGroup, Cell, FooterGroup, HeaderGroup, Row, Table as Root};
+
+    let cell = |label| {
+        Node::element(label, "td", Table(Cell), None, Vec::new()).with_metadata(
+            LayoutElementMetadata {
+                table: Some(LayoutTableData::default()),
+                ..LayoutElementMetadata::default()
+            },
+        )
+    };
+    // Deliberately place tbody and tfoot before thead in tree order. CSS table
+    // layout promotes the first header group before all bodies and the first
+    // footer group after them.
+    let source = Source(vec![
+        Node::element("root", "div", LayoutElementCategory::Generic, None, vec![1]),
+        Node::element("table", "table", Table(Root), None, vec![2, 6, 10]),
+        Node::element("body", "tbody", Table(BodyGroup), None, vec![3]),
+        Node::element("body-row", "tr", Table(Row), None, vec![4, 5]),
+        cell("body-a"),
+        cell("body-b"),
+        Node::element("footer", "tfoot", Table(FooterGroup), None, vec![7]),
+        Node::element("footer-row", "tr", Table(Row), None, vec![8, 9]),
+        cell("footer-a"),
+        cell("footer-b"),
+        Node::element("header", "thead", Table(HeaderGroup), None, vec![11]),
+        Node::element("header-row", "tr", Table(Row), None, vec![12, 13]),
+        cell("header-a"),
+        cell("header-b"),
+    ]);
+    let body_a = PaintColor::new(0.11, 0.12, 0.13, 1.0);
+    let body_b = PaintColor::new(0.21, 0.22, 0.23, 1.0);
+    let footer_a = PaintColor::new(0.31, 0.32, 0.33, 1.0);
+    let footer_b = PaintColor::new(0.41, 0.42, 0.43, 1.0);
+    let header_a = PaintColor::new(0.51, 0.52, 0.53, 1.0);
+    let header_b = PaintColor::new(0.61, 0.62, 0.63, 1.0);
+    let mut styles = Styles::default();
+    styles.primary.insert(
+        0,
+        sized(LayoutDisplay::Block, 200.0, 100.0, PaintColor::TRANSPARENT),
+    );
+    styles.primary.insert(
+        1,
+        sized(LayoutDisplay::Table, 100.0, 30.0, PaintColor::TRANSPARENT),
+    );
+    styles.primary.insert(
+        2,
+        style(LayoutDisplay::TableRowGroup, PaintColor::TRANSPARENT),
+    );
+    styles
+        .primary
+        .insert(3, style(LayoutDisplay::TableRow, PaintColor::TRANSPARENT));
+    styles
+        .primary
+        .insert(4, sized(LayoutDisplay::TableCell, 20.0, 10.0, body_a));
+    styles
+        .primary
+        .insert(5, sized(LayoutDisplay::TableCell, 80.0, 10.0, body_b));
+    styles.primary.insert(
+        6,
+        style(LayoutDisplay::TableFooterGroup, PaintColor::TRANSPARENT),
+    );
+    styles
+        .primary
+        .insert(7, style(LayoutDisplay::TableRow, PaintColor::TRANSPARENT));
+    styles
+        .primary
+        .insert(8, sized(LayoutDisplay::TableCell, 50.0, 10.0, footer_a));
+    styles
+        .primary
+        .insert(9, sized(LayoutDisplay::TableCell, 50.0, 10.0, footer_b));
+    styles.primary.insert(
+        10,
+        style(LayoutDisplay::TableHeaderGroup, PaintColor::TRANSPARENT),
+    );
+    styles
+        .primary
+        .insert(11, style(LayoutDisplay::TableRow, PaintColor::TRANSPARENT));
+    styles
+        .primary
+        .insert(12, sized(LayoutDisplay::TableCell, 75.0, 10.0, header_a));
+    styles
+        .primary
+        .insert(13, sized(LayoutDisplay::TableCell, 25.0, 10.0, header_b));
+
+    let snapshot = render(&source, &mut styles, 200, 100);
+    for (color, expected) in [
+        (header_a, (0.0, 0.0, 75.0)),
+        (header_b, (75.0, 0.0, 25.0)),
+        (body_a, (0.0, 10.0, 75.0)),
+        (body_b, (75.0, 10.0, 25.0)),
+        (footer_a, (0.0, 20.0, 75.0)),
+        (footer_b, (75.0, 20.0, 25.0)),
+    ] {
+        let actual = rect(&snapshot, color);
+        assert_close(actual.x, expected.0);
+        assert_close(actual.y, expected.1);
+        assert_close(actual.width, expected.2);
+        assert_close(actual.height, 10.0);
+    }
+}
+
+#[test]
 fn left_float_restricts_inline_slots_and_clear_moves_the_next_block_below_it() {
     let source = Source(vec![
         Node::element(

--- a/moli-renderer-v8/src/runtime/phase_one/mod.rs
+++ b/moli-renderer-v8/src/runtime/phase_one/mod.rs
@@ -954,6 +954,61 @@ td{padding:0;border:0;height:10px}
     }
 
     #[test]
+    fn fixed_table_layout_distributes_first_row_colspan_constraints() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime should build");
+
+        runtime.block_on(tokio::task::LocalSet::new().run_until(async move {
+            let snapshot = render_test_snapshot(
+                r#"<!doctype html><html><head><style>
+html,body{margin:0;padding:0}
+table{table-layout:fixed;border-spacing:0}td{border:0;padding:0;height:10px}
+#lengths{width:300px}#l0{background:rgb(10,20,30)}#l1{background:rgb(20,30,40)}#l2{background:rgb(30,40,50)}#l3{background:rgb(40,50,60)}
+#percents{width:500px}#p0{background:rgb(50,60,70)}#p1{background:rgb(60,70,80)}#p2{background:rgb(70,80,90)}#p3{background:rgb(80,90,100)}#p4{background:rgb(90,100,110)}
+#priority{width:300px}#c0{background:rgb(100,110,120)}#c1{background:rgb(110,120,130)}#c2{background:rgb(120,130,140)}
+#spacing{width:350px;border-spacing:10px}#s0{background:rgb(130,140,150)}#s1{background:rgb(140,150,160)}#s2{background:rgb(150,160,170)}#s3{background:rgb(160,170,180)}
+</style></head><body>
+<table id=lengths><tr><td colspan=2 style="width:100px"></td><td colspan=2 style="width:200px"></td></tr><tr><td id=l0></td><td id=l1></td><td id=l2></td><td id=l3></td></tr></table>
+<table id=percents><tr><td colspan=2 style="width:40%"></td><td colspan=2 style="width:20%"></td><td style="width:40%"></td></tr><tr><td id=p0></td><td id=p1></td><td id=p2></td><td id=p3></td><td id=p4></td></tr></table>
+<table id=priority><col style="width:80px"><col><col><tr><td colspan=2 style="width:200px"></td><td></td></tr><tr><td id=c0></td><td id=c1></td><td id=c2></td></tr></table>
+<table id=spacing><tr><td colspan=2 style="width:110px"></td><td colspan=2 style="width:210px"></td></tr><tr><td id=s0></td><td id=s1></td><td id=s2></td><td id=s3></td></tr></table>
+</body></html>"#,
+            )
+            .await;
+
+            // These values are Chromium's fixed-table constraint geometry.
+            // Wide first-row cells contribute one constraint that is divided
+            // over their tracks; explicit columns retain priority, and inner
+            // border-spacing is removed before division.
+            for (color, expected) in [
+                (rgb(10, 20, 30), (0.0, 10.0, 50.0)),
+                (rgb(20, 30, 40), (50.0, 10.0, 50.0)),
+                (rgb(30, 40, 50), (100.0, 10.0, 100.0)),
+                (rgb(40, 50, 60), (200.0, 10.0, 100.0)),
+                (rgb(50, 60, 70), (0.0, 30.0, 100.0)),
+                (rgb(60, 70, 80), (100.0, 30.0, 100.0)),
+                (rgb(70, 80, 90), (200.0, 30.0, 50.0)),
+                (rgb(80, 90, 100), (250.0, 30.0, 50.0)),
+                (rgb(90, 100, 110), (300.0, 30.0, 200.0)),
+                (rgb(100, 110, 120), (0.0, 50.0, 80.0)),
+                (rgb(110, 120, 130), (80.0, 50.0, 100.0)),
+                (rgb(120, 130, 140), (180.0, 50.0, 120.0)),
+                (rgb(130, 140, 150), (10.0, 90.0, 50.0)),
+                (rgb(140, 150, 160), (70.0, 90.0, 50.0)),
+                (rgb(150, 160, 170), (130.0, 90.0, 100.0)),
+                (rgb(160, 170, 180), (240.0, 90.0, 100.0)),
+            ] {
+                assert_paint_rect(
+                    solid_paint_rect(&snapshot, color),
+                    moli_layout::PaintRect::new(expected.0, expected.1, expected.2, 10.0),
+                );
+            }
+        }));
+    }
+
+    #[test]
     fn fixed_table_layout_grows_to_its_definite_column_minimum() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()


### PR DESCRIPTION
Order table sections visually before applying first-row span constraints, preserve explicit column priority, and exclude internal border spacing from distributed cell measures.