### PR TITLE
feat(nix): add a flake that builds Moli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ __pycache__
 /moli-benchmark/moli-benchmark/
 
 node_modules
+
+# `nix build` output symlink
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ On Windows, run in PowerShell:
 irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex
 ```
 
+### Nix
+
+Run Moli without installing it:
+
+```sh
+nix run github:lexmount/moli -- fetch --dump markdown https://example.com
+```
+
+Build it, or enter a shell with the toolchain this repository needs:
+
+```sh
+nix build github:lexmount/moli
+nix develop github:lexmount/moli
+```
+
 ## Showcase
 
 <p align="center">

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,12 +13,21 @@
         "x86_64-linux"
       ];
       forEachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+      # A clean checkout exposes `self.rev`, a dirty one exposes only
+      # `self.dirtyRev` — which Nix formats as `<commit>-dirty` — and a source
+      # that is not a git tree exposes neither. The CDP revision contract in
+      # `moli-protocol/src/version.rs` accepts a bare 40- or 64-digit hex hash
+      # only, so drop the suffix and fall back to git's all-zero "no such
+      # commit" sentinel rather than a word that cannot parse as a hash.
+      nullRev = "0000000000000000000000000000000000000000";
+      revision = nixpkgs.lib.removeSuffix "-dirty" (self.rev or self.dirtyRev or nullRev);
     in
     {
       packages = forEachSystem (pkgs: rec {
         moli = pkgs.callPackage ./nix/package.nix {
           src = self;
-          revision = self.rev or self.dirtyRev or "unknown";
+          inherit revision;
         };
         default = moli;
       });

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "Moli: a lite, fast, high-compatibility headless browser for AI agents";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      forEachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forEachSystem (pkgs: rec {
+        moli = pkgs.callPackage ./nix/package.nix {
+          src = self;
+          revision = self.rev or self.dirtyRev or "unknown";
+        };
+        default = moli;
+      });
+
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.callPackage ./nix/shell.nix { };
+      });
+
+      # `nixfmt` formats files, not directories, so `nix fmt` needs a wrapper
+      # that walks the tree it is handed.
+      formatter = forEachSystem (
+        pkgs:
+        pkgs.writeShellApplication {
+          name = "nixfmt-tree";
+          runtimeInputs = [
+            pkgs.findutils
+            pkgs.nixfmt
+          ];
+          text = ''find "''${@:-.}" -type f -name '*.nix' -exec nixfmt {} +'';
+        }
+      );
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,128 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchurl,
+  cmake,
+  perl,
+  pkg-config,
+  python3,
+  src,
+  revision ? "unknown",
+  version ? "1.0.2",
+}:
+
+let
+  # The vendored `v8` crate links a prebuilt static library that its build
+  # script downloads over the network. `RUSTY_V8_ARCHIVE` is copied rather than
+  # downloaded whenever it is not an http(s) URL, so pointing it at a
+  # fixed-output fetch keeps the build sandbox-clean. Building V8 from source is
+  # not an option here: the vendored tree is prebuilt-only and rejects
+  # `V8_FROM_SOURCE`.
+  rustyV8Version = "146.9.0";
+
+  archives = {
+    aarch64-darwin = {
+      target = "aarch64-apple-darwin";
+      hash = "sha256-5N5IQxBpGKWBEemXd4Y7nLdXzCg+ZcBb11Td0mbjokI=";
+    };
+    aarch64-linux = {
+      target = "aarch64-unknown-linux-gnu";
+      hash = "sha256-Jk7v/5DEnFmbLCGGzIaZVjtzeL6k66CY/p6mXZvFt9I=";
+    };
+    x86_64-darwin = {
+      target = "x86_64-apple-darwin";
+      hash = "sha256-YOv8BnCfL7vFkmiar+VDbxdiJ95OpXZvGKm9OfDjtP0=";
+    };
+    x86_64-linux = {
+      target = "x86_64-unknown-linux-gnu";
+      hash = "sha256-Yu8vHivMad6I+uo1iXMIRBVrziVVUZ+7IiXYpbiB/pg=";
+    };
+  };
+
+  inherit (stdenv.hostPlatform) system;
+
+  archive =
+    archives.${system} or (throw "moli: no prebuilt V8 static library is published for ${system}");
+
+  librustyV8 = fetchurl {
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_release_${archive.target}.a.gz";
+    inherit (archive) hash;
+  };
+in
+
+rustPlatform.buildRustPackage {
+  pname = "moli";
+  inherit version src;
+
+  # `cargoHash` rather than `cargoLock`: moli patches in a fork of curl-rust
+  # that carries libcurl as a git submodule, and only the fetchCargoVendor path
+  # behind `cargoHash` passes `--fetch-submodules`. With `cargoLock` the
+  # submodule arrives empty and the static libcurl build fails.
+  cargoHash = "sha256-lNZ7lUE/Xfq8otL2JA6Td3sZ8pNjq2XGE/vSYsN8n7o=";
+
+  nativeBuildInputs = [
+    cmake
+    perl # openssl-src compiles OpenSSL from source
+    pkg-config
+    python3 # stylo generates its property tables with mako at build time
+    rustPlatform.bindgenHook
+  ];
+
+  # A dependency ships CMake files, but the workspace itself is pure Cargo, so
+  # the CMake setup hook must not try to configure the source root.
+  dontUseCmakeConfigure = true;
+
+  # `moli-protocol` builds its revision string by shelling out to git, and a
+  # Nix source tree carries no `.git`. vergen's `fail_on_error` makes that a
+  # hard failure that `VERGEN_IDEMPOTENT` cannot soften, so emit the revision
+  # the caller already knows rather than pulling a git repository into the
+  # sandbox.
+  postPatch = ''
+    echo 'fn main() { println!("cargo:rustc-env=VERGEN_GIT_SHA=${revision}"); }' \
+      > moli-protocol/build.rs
+  '';
+
+  # The `lightmount` curl-sys fork builds vendored libcurl with brotli, and
+  # finds brotli's C headers by scanning `$CARGO_HOME` and a `vendor/`
+  # directory beside its own manifest. Neither exists in the Nix vendor
+  # layout, so place the vendored brotlic-sys crate where that scan looks.
+  # The cargo setup hook copies the vendor tree into the build directory and
+  # makes it writable for exactly this kind of build script.
+  preBuild = ''
+    curlSys=$(find "$NIX_BUILD_TOP" -maxdepth 4 -type d -name 'curl-sys-*' -print -quit)
+    brotliSys=$(find "$NIX_BUILD_TOP" -maxdepth 4 -type d -name 'brotlic-sys-*' -print -quit)
+    if [ -z "$curlSys" ] || [ -z "$brotliSys" ]; then
+      echo "moli: expected vendored curl-sys and brotlic-sys crates" >&2
+      exit 1
+    fi
+    mkdir -p "$(dirname "$curlSys")/vendor"
+    ln -sfn "$brotliSys" "$(dirname "$curlSys")/vendor/$(basename "$brotliSys")"
+  '';
+
+  env.RUSTY_V8_ARCHIVE = librustyV8;
+
+  # Only the CLI is an installable artifact; the rest of the workspace is
+  # library crates.
+  cargoBuildFlags = [
+    "--package"
+    "moli"
+    "--bin"
+    "moli"
+  ];
+
+  # The suite binds loopback HTTP servers and drives a full browser runtime,
+  # neither of which the build sandbox can host.
+  doCheck = false;
+
+  meta = {
+    description = "Lite, fast, high-compatibility headless browser for AI agents";
+    homepage = "https://github.com/lexmount/moli";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    mainProgram = "moli";
+    platforms = builtins.attrNames archives;
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,31 @@
+{
+  mkShell,
+  cargo,
+  cargo-nextest,
+  clippy,
+  cmake,
+  perl,
+  pkg-config,
+  python3,
+  rustc,
+  rustPlatform,
+  rustfmt,
+}:
+
+mkShell {
+  # A dev shell is not sandboxed, so the `v8` build script can fetch its own
+  # prebuilt archive. Only the native toolchain has to be provided here.
+  packages = [
+    cargo
+    cargo-nextest
+    clippy
+    cmake
+    perl
+    pkg-config
+    python3
+    rustc
+    rustfmt
+  ];
+
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -4,6 +4,8 @@
   cargo-nextest,
   clippy,
   cmake,
+  curl,
+  git,
   perl,
   pkg-config,
   python3,
@@ -14,12 +16,17 @@
 
 mkShell {
   # A dev shell is not sandboxed, so the `v8` build script can fetch its own
-  # prebuilt archive. Only the native toolchain has to be provided here.
+  # prebuilt archive instead of taking one through `RUSTY_V8_ARCHIVE`. That
+  # fetch shells out to Deno or `curl`, and the slim vendored tree drops the
+  # `tools/download_file.py` fallback, so `curl` has to be here. `git` is here
+  # because `moli-protocol/build.rs` runs vergen-gitcl under `fail_on_error`.
   packages = [
     cargo
     cargo-nextest
     clippy
     cmake
+    curl
+    git
     perl
     pkg-config
     python3


### PR DESCRIPTION
Refs #118.

Moli could not be built with Nix at all, so packaging it for nixpkgs had no starting point. This adds a flake that builds the CLI, plus a dev shell and a formatter.

```console
$ nix run github:lexmount/moli -- fetch --dump markdown https://example.com
$ nix build github:lexmount/moli
$ nix develop github:lexmount/moli
```

## Scope

This is the buildable foundation, **not** the nixpkgs submission itself — `search.nixos.org` needs a separate PR against NixOS/nixpkgs. `nix/package.nix` is deliberately split from `flake.nix` and takes `src`, `version`, and `revision` as arguments, so it can be lifted into nixpkgs with a `fetchFromGitHub` src and no rewrite. Happy to follow up with that submission if you want it.

## What a sandboxed build runs into

Four things in this workspace block a Nix build. Each is commented where it is worked around, because none of them is guessable from the outside:

**The vendored `v8` crate downloads a prebuilt static library from its build script**, and Nix builds have no network. There is no source-build escape hatch — the vendored tree is prebuilt-only and explicitly rejects `V8_FROM_SOURCE`. The way through is that `download_file` copies rather than downloads when `RUSTY_V8_ARCHIVE` is not an `http(s):` URL, so a fixed-output `fetchurl` satisfies it. The V8 src bindings are already vendored under `vendor/v8-146.9.0/gen/`, so nothing else is fetched.

**The pinned curl-rust fork carries libcurl as a git submodule.** This one is a trap: `cargoLock` uses `importCargoLock`, which calls `fetchgit` *without* `fetchSubmodules`, so the submodule arrives empty and the `static-curl` build fails. Only the `fetchCargoVendor` path behind `cargoHash` passes `--fetch-submodules`. `cargoHash` is therefore mandatory here, and switching to `cargoLock` later would silently break the build.

**That same fork locates brotli's C headers by scanning** `$CARGO_HOME` and a `vendor/` directory beside its own manifest. Neither exists in the Nix vendor layout, so `preBuild` links the vendored `brotlic-sys` crate into a path that scan reaches.

**`moli-protocol` derives the binary revision by shelling out to git**, and a Nix source tree has no `.git`. vergen's `fail_on_error` makes that fatal in a way `VERGEN_IDEMPOTENT` cannot soften (`gitcl` returns the error before ever consulting the idempotent flag). Rather than carry a git repository into the sandbox, `postPatch` emits the revision the flake already knows — which is more accurate than what a tarball build would produce.

Beyond those, `stylo` needs Python at build time for its property tables, and `bindgen` needs libclang via `rustPlatform.bindgenHook`.

`doCheck = false`: the suite binds loopback HTTP servers and drives a full browser runtime, neither of which the sandbox can host.

## Testing

Verified on **aarch64-darwin**:

- `nix build` succeeds
- `nix run .#moli -- --version` works
- `nix flake check` passes
- `nix fmt` runs clean and is idempotent
- the resulting binary fetches a live page, and correctly refuses a `robots.txt`-disallowed URL

**Only aarch64-darwin was actually built.** The V8 archive hashes for the other three platforms come from downloading and hashing the published release assets, so they are real values rather than placeholders, but those builds are unverified. If CI or a Linux user hits something, I would expect it in the `curl-sys` or `stylo` native-dependency area rather than in the V8 wiring.

`nixfmt` formats files rather than directories, so `formatter` is a small wrapper that walks the tree; a bare `pkgs.nixfmt` makes `nix fmt` fail.
