### PR TITLE
Add star history chart to the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,15 @@ Its current intentional boundaries include:
 Unsupported protocol paths return explicit errors — Moli never pretends that a
 browser action, event, network observation, or visual result occurred.
 
+## Star history
+
+Generated hourly from the stargazer timeline by [lexmount/moli-metrics](https://github.com/lexmount/moli-metrics).
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history-dark.svg">
+  <img alt="Star history of lexmount/moli" src="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history.svg" width="100%">
+</picture>
+
 ## License
 
 Unless a file or directory states otherwise, you may use Moli under either the

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -268,6 +268,15 @@ Zu den aktuell bewusst gesetzten Grenzen gehören:
 
 Nicht unterstützte Protokollpfade liefern einen eindeutigen Fehler zurück — Moli täuscht nie vor, dass eine Browseraktion, ein Ereignis, eine Netzwerkbeobachtung oder ein visuelles Ergebnis stattgefunden hätte.
 
+## Star-Verlauf
+
+Stündlich aus der Stargazer-Timeline erzeugt von [lexmount/moli-metrics](https://github.com/lexmount/moli-metrics).
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history-dark.svg">
+  <img alt="Star-Verlauf von lexmount/moli" src="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history.svg" width="100%">
+</picture>
+
 ## Lizenz
 
 Sofern eine Datei oder ein Verzeichnis nichts anderes angibt, kann Moli wahlweise unter der [Apache License 2.0](../LICENSE-APACHE) oder der [MIT License](../LICENSE-MIT) genutzt werden. Separat lizenzierte Komponenten und Fixtures von Drittanbietern unterliegen weiterhin ihren jeweiligen Lizenzen und Hinweisen.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -268,6 +268,15 @@ Estos son los límites que se mantienen a propósito:
 
 Los caminos de protocolo no soportados devuelven un error explícito: Moli nunca finge que ha ocurrido una acción del navegador, un evento, una observación de red o un resultado visual.
 
+## Historial de stars
+
+Generado cada hora a partir de la cronología de stars por [lexmount/moli-metrics](https://github.com/lexmount/moli-metrics).
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history-dark.svg">
+  <img alt="Historial de stars de lexmount/moli" src="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history.svg" width="100%">
+</picture>
+
 ## Licencia
 
 Salvo que se indique lo contrario en un archivo o directorio concreto, Moli puede usarse, a elección de quien lo use, bajo la [Licencia Apache 2.0](../LICENSE-APACHE) o la [Licencia MIT](../LICENSE-MIT). Los componentes y fixtures de terceros con licencia propia siguen sujetos a sus respectivas licencias y avisos.

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -268,6 +268,15 @@ Voici les limites actuellement conservées de façon délibérée :
 
 Les chemins de protocole non pris en charge renvoient toujours une erreur explicite : Moli ne fait jamais semblant qu'une action du navigateur, un événement, une observation réseau ou un résultat visuel a eu lieu.
 
+## Historique des stars
+
+Généré chaque heure à partir de la chronologie des stars par [lexmount/moli-metrics](https://github.com/lexmount/moli-metrics).
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history-dark.svg">
+  <img alt="Historique des stars de lexmount/moli" src="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history.svg" width="100%">
+</picture>
+
 ## Licence
 
 Sauf mention contraire dans un fichier ou un répertoire donné, Moli est disponible, au choix, sous [licence Apache 2.0](../LICENSE-APACHE) ou sous [licence MIT](../LICENSE-MIT). Les composants et fixtures tiers sous licence distincte restent soumis à leurs propres licences et mentions.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -267,6 +267,15 @@ Kitesurf はリモートサービスのため、CPU、メモリ、プロセス�
 
 未対応の操作には、明確なエラーを返します。Moli は、実行していないブラウザ操作やイベント、通信状況の確認、画面出力を、実行済みであるかのように扱うことはありません。
 
+## Star の推移
+
+[lexmount/moli-metrics](https://github.com/lexmount/moli-metrics) が stargazer タイムラインから毎時自動生成しています。
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history-dark.svg">
+  <img alt="lexmount/moli の Star 推移" src="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history.svg" width="100%">
+</picture>
+
 ## ライセンス
 
 ファイルまたはディレクトリに別の記載がない限り、Moli は [Apache License 2.0](../LICENSE-APACHE) または [MIT License](../LICENSE-MIT) のいずれかを選択して利用できます。個別のライセンスが適用される第三者提供の構成要素やテスト用データについては、それぞれのライセンスと告知事項に従います。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -267,6 +267,15 @@ Kitesurf 是远程服务，无法测量 CPU、内存和进程数，因此资源�
 
 遇到不支持的协议路径，Moli 会直接明确报错——它不会假装某个浏览器操作、事件、网络观测或者视觉结果已经发生。
 
+## Star 趋势
+
+由 [lexmount/moli-metrics](https://github.com/lexmount/moli-metrics) 每小时根据 star 时间线自动生成。
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history-dark.svg">
+  <img alt="lexmount/moli 的 Star 增长曲线" src="https://raw.githubusercontent.com/lexmount/moli-metrics/main/assets/star-history.svg" width="100%">
+</picture>
+
 ## 许可证
 
 除非文件或目录中另有说明，你可以自行选择依据 [Apache License 2.0](../LICENSE-APACHE) 或 [MIT License](../LICENSE-MIT) 来使用 Moli。采用独立许可证的第三方组件和测试夹具，仍然遵循各自的许可证和声明。


### PR DESCRIPTION
Adds a **Star history** section between *Project scope* and *License*, in all six language READMEs.

The chart is served from [lexmount/moli-metrics](https://github.com/lexmount/moli-metrics), a separate public repo that regenerates it hourly from the stargazer timeline and commits only when the count actually changed — so this repo's history stays free of metrics commits, which was the reason for splitting it out.

It uses the same `<picture>` theme-switching pattern as the existing benchmark charts, so it follows the reader's light/dark setting. Verified that both raw URLs return `200 image/svg+xml`, and that GitHub's markdown renderer preserves the `<picture>`/`<source>` markup rather than sanitizing it away.

One caveat worth knowing: GitHub proxies README images through camo, which caches them. The chart on this page will therefore lag the source SVG by however long camo holds its copy — the underlying data is hourly, but the rendered image is not guaranteed to be.