### PR TITLE
fix(encoding): rewrite meta-declared UTF-16 to UTF-8

### DIFF
--- a/moli-charset-parser/src/prescan.rs
+++ b/moli-charset-parser/src/prescan.rs
@@ -186,7 +186,27 @@ fn html_token_attr_value(tag: &Tag, name: &str) -> Option<String> {
 }
 
 fn encoding_for_label(label: String) -> Option<&'static Encoding> {
-    Encoding::for_label(label.trim().as_bytes())
+    Encoding::for_label(label.trim().as_bytes()).map(prescan_charset_override)
+}
+
+/// Applies the two charset rewrites the prescan performs before returning a
+/// label it found on a `meta` element.
+///
+/// A prescan only ever reaches a `meta` element through ASCII-compatible
+/// bytes, so a document that declares a UTF-16 encoding there has necessarily
+/// mislabeled itself, and the standard decodes it as UTF-8 instead.
+/// `x-user-defined` is likewise rewritten to windows-1252, leaving its
+/// private-use mapping to apply only when the transport layer asked for it.
+///
+/// <https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding>
+fn prescan_charset_override(encoding: &'static Encoding) -> &'static Encoding {
+    if encoding == encoding_rs::UTF_16BE || encoding == encoding_rs::UTF_16LE {
+        encoding_rs::UTF_8
+    } else if encoding == encoding_rs::X_USER_DEFINED {
+        encoding_rs::WINDOWS_1252
+    } else {
+        encoding
+    }
 }
 
 fn charset_from_content_type(value: &str) -> Option<String> {

--- a/moli-charset-parser/src/tests.rs
+++ b/moli-charset-parser/src/tests.rs
@@ -135,3 +135,62 @@ fn finish_reports_not_found() {
     );
     assert_eq!(parser.finish(), HtmlMetaCharsetScanResult::NotFound);
 }
+
+#[test]
+fn meta_declared_utf16_is_rewritten_to_utf8() {
+    for label in ["utf-16", "utf-16le", "utf-16be", "UTF-16BE", "  utf-16  "] {
+        let input = format!(r#"<meta charset="{label}">"#);
+        assert_eq!(
+            sniff_html_meta_charset(input.as_bytes()).map(Encoding::name),
+            Some("UTF-8"),
+            "charset={label}"
+        );
+    }
+}
+
+#[test]
+fn meta_declared_x_user_defined_is_rewritten_to_windows1252() {
+    assert_eq!(
+        sniff_html_meta_charset(br#"<meta charset="x-user-defined">"#).map(Encoding::name),
+        Some("windows-1252")
+    );
+}
+
+#[test]
+fn content_type_pragma_charset_is_rewritten_too() {
+    assert_eq!(
+        sniff_html_meta_charset(
+            br#"<meta http-equiv="content-type" content="text/html; charset=utf-16">"#
+        )
+        .map(Encoding::name),
+        Some("UTF-8")
+    );
+    assert_eq!(
+        sniff_html_meta_charset(
+            br#"<meta http-equiv="content-type" content="text/html; charset=x-user-defined">"#
+        )
+        .map(Encoding::name),
+        Some("windows-1252")
+    );
+}
+
+#[test]
+fn other_meta_charset_labels_are_left_alone() {
+    for (label, expected) in [
+        ("utf-8", "UTF-8"),
+        ("gbk", "GBK"),
+        ("shift_jis", "Shift_JIS"),
+        ("iso-8859-1", "windows-1252"),
+    ] {
+        let input = format!(r#"<meta charset="{label}">"#);
+        assert_eq!(
+            sniff_html_meta_charset(input.as_bytes()).map(Encoding::name),
+            Some(expected),
+            "charset={label}"
+        );
+    }
+
+    // A label outside the Encoding Standard is still no match at all, rather
+    // than being rewritten to one of the two replacements above.
+    assert_eq!(sniff_html_meta_charset(br#"<meta charset="utf-32">"#), None);
+}

--- a/moli-encoding/src/tests.rs
+++ b/moli-encoding/src/tests.rs
@@ -447,3 +447,48 @@ fn url_query_encoder_leaves_utf8_and_queryless_inputs_borrowed() {
         Cow::Borrowed(_)
     ));
 }
+
+#[test]
+fn meta_declared_utf16_document_decodes_as_utf8() {
+    let (text, encoding) = decode_html_document(
+        br#"<!DOCTYPE html><meta charset="utf-16"><p>Hello, world!</p>"#,
+        &[],
+    );
+
+    assert_eq!(encoding, "UTF-8");
+    assert!(text.contains("Hello, world!"), "decoded as {text:?}");
+}
+
+/// `encoding_rs` has no UTF-16 encoder — the Encoding Standard replaces it
+/// with UTF-8 for output — so UTF-16LE input has to be built by hand.
+fn utf16le_bytes(input: &str) -> Vec<u8> {
+    input
+        .encode_utf16()
+        .flat_map(|unit| unit.to_le_bytes())
+        .collect()
+}
+
+#[test]
+fn meta_declared_utf16_does_not_override_a_bom() {
+    let mut input = vec![0xFF, 0xFE];
+    input.extend_from_slice(&utf16le_bytes("<meta charset=\"utf-16\">hi"));
+
+    let (text, encoding) = decode_html_document(&input, &[]);
+
+    assert_eq!(encoding, "UTF-16LE");
+    assert!(text.ends_with("hi"), "decoded as {text:?}");
+}
+
+#[test]
+fn transport_utf16_still_wins_over_the_meta_rewrite() {
+    let headers = vec![(
+        "Content-Type".to_owned(),
+        "text/html; charset=utf-16le".to_owned(),
+    )];
+    let input = utf16le_bytes("<meta charset=\"utf-16\">hi");
+
+    let (text, encoding) = decode_html_document(&input, &headers);
+
+    assert_eq!(encoding, "UTF-16LE");
+    assert!(text.ends_with("hi"), "decoded as {text:?}");
+}


### PR DESCRIPTION
Fixes #152.

A document whose only encoding declaration is `<meta charset="utf-16">` was decoded as UTF-16, folding every byte pair into one CJK code point. The damage was not confined to text — the tokenizer saw no markup either, so the whole document collapsed into a single text node inside `<body>`:

```console
$ moli fetch --dump html http://127.0.0.1:8731/index.html
<html><head></head><body>ℼ佄呃偙⁅瑨汭ਾ洼瑥⁡档牡敳㵴產晴ㄭ∶ਾ琼瑩敬刾灥潲⼼楴汴㹥㰊㹰效汬Ɐ眠牯摬㰡瀯ਾ</body></html>
```

With this change:

```console
$ moli fetch --dump html http://127.0.0.1:8731/index.html
<!DOCTYPE html><html><head><meta charset="utf-16">
<title>Repro</title>
</head><body><p>Hello, world!</p>
</body></html>

$ moli fetch --dump markdown http://127.0.0.1:8731/index.html
Hello, world!
```

### The rule

A prescan reaches a `meta` element only by reading ASCII-compatible bytes, so a document it can see that declares UTF-16 has necessarily mislabeled itself. [The HTML Standard](https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding) rewrites the charset before returning it:

> If charset is UTF-16BE/LE, then set charset to UTF-8.
>
> If charset is x-user-defined, then set charset to windows-1252.

### Where the rewrite lives

In `moli-charset-parser`, on the shared `encoding_for_label` helper, so the `meta charset` and `http-equiv=content-type` paths are both covered by one change.

Putting it there rather than in `moli-encoding` matters: it keeps the rewrite scoped to the meta path and leaves the two neighbouring paths that legitimately select UTF-16 untouched.

- A UTF-16 **BOM** still selects UTF-16 — `encoding_for_document_bom` runs before the prescan.
- A UTF-16 charset on the **transport layer** still selects UTF-16 — the encoding sniffing algorithm takes the transport encoding with confidence *certain* and applies no rewrite.

Both are pinned by new regression tests, so a later move of this logic up into `moli-encoding` would fail loudly rather than silently breaking them.

### Tests

Added to `moli-charset-parser`:

- meta-declared `utf-16`, `utf-16le`, `utf-16be` (and mixed case / surrounding whitespace) all resolve to UTF-8
- meta-declared `x-user-defined` resolves to windows-1252
- both rewrites also apply through `http-equiv="content-type"`
- unrelated labels are untouched (`utf-8`, `gbk`, `shift_jis`, `iso-8859-1` → windows-1252), and a label outside the Encoding Standard (`utf-32`) is still no match rather than being rewritten

Added to `moli-encoding`:

- an end-to-end `decode_html_document` case: the mislabeled document decodes as UTF-8 and the text survives
- a UTF-16 BOM still wins over a conflicting `meta charset`
- a transport `charset=utf-16le` still wins over a conflicting `meta charset`

`cargo test -p moli-charset-parser -p moli-encoding` passes 55 tests; `cargo fmt --check` and `cargo clippy --all-targets` are clean for both crates. The before/after CLI output above was produced on aarch64-darwin against a local `python3 -m http.server` that sends `Content-type: text/html` with no charset.
