### PR TITLE
fix(encoding): extract meta content-type charset per the standard

### DIFF
--- a/moli-charset-parser/src/prescan.rs
+++ b/moli-charset-parser/src/prescan.rs
@@ -209,24 +209,68 @@ fn prescan_charset_override(encoding: &'static Encoding) -> &'static Encoding {
     }
 }
 
+const CHARSET_KEYWORD: &[u8] = b"charset";
+
+/// Extracts a character encoding label from a `meta` element's `content`
+/// attribute.
+///
+/// This is the HTML Standard's own algorithm rather than a MIME parameter
+/// parse: it searches for the literal `charset` anywhere in the value, so a
+/// `content` attribute carrying no media type still yields its label, and it
+/// terminates an unquoted label at the first ASCII whitespace or `;`. A label
+/// opened with a quote must be closed by the same quote, otherwise the
+/// attribute contributes nothing.
+///
+/// <https://html.spec.whatwg.org/multipage/parsing.html#algorithm-for-extracting-a-character-encoding-from-a-meta-element>
 fn charset_from_content_type(value: &str) -> Option<String> {
-    for parameter in value.split(';').skip(1) {
-        let parameter = parameter.trim();
-        let Some((name, value)) = parameter.split_once('=') else {
-            continue;
-        };
-        if !name.trim().eq_ignore_ascii_case("charset") {
+    let bytes = value.as_bytes();
+    let mut position = 0;
+
+    loop {
+        let offset = bytes[position..]
+            .windows(CHARSET_KEYWORD.len())
+            .position(|window| window.eq_ignore_ascii_case(CHARSET_KEYWORD))?;
+        let keyword_end = position + offset + CHARSET_KEYWORD.len();
+        let separator = keyword_end + leading_ascii_whitespace(&bytes[keyword_end..]);
+
+        if bytes.get(separator) != Some(&b'=') {
+            // The keyword was not a label assignment, so resume the search
+            // just past it rather than rescanning the same match forever.
+            position = separator.max(keyword_end);
             continue;
         }
-        let value = value
-            .trim()
-            .trim_matches(|ch| ch == '"' || ch == '\'')
-            .trim();
-        if !value.is_empty() {
-            return Some(value.to_owned());
+
+        let label_start = separator + 1;
+        let label_start = label_start + leading_ascii_whitespace(&bytes[label_start..]);
+        return charset_label_at(value, label_start).map(str::to_owned);
+    }
+}
+
+fn charset_label_at(value: &str, start: usize) -> Option<&str> {
+    let bytes = value.as_bytes();
+    match bytes.get(start) {
+        Some(&quote) if quote == b'"' || quote == b'\'' => {
+            let quoted_start = start + 1;
+            let quoted_len = bytes[quoted_start..]
+                .iter()
+                .position(|byte| *byte == quote)?;
+            Some(&value[quoted_start..quoted_start + quoted_len])
+        }
+        _ => {
+            let end = bytes[start..]
+                .iter()
+                .position(|byte| byte.is_ascii_whitespace() || *byte == b';')
+                .map_or(bytes.len(), |offset| start + offset);
+            Some(&value[start..end])
         }
     }
-    None
+}
+
+fn leading_ascii_whitespace(bytes: &[u8]) -> usize {
+    bytes
+        .iter()
+        .take_while(|byte| byte.is_ascii_whitespace())
+        .count()
 }
 
 fn byte_prescan_input_as_latin1(bytes: &[u8]) -> String {

--- a/moli-charset-parser/src/tests.rs
+++ b/moli-charset-parser/src/tests.rs
@@ -194,3 +194,103 @@ fn other_meta_charset_labels_are_left_alone() {
     // than being rewritten to one of the two replacements above.
     assert_eq!(sniff_html_meta_charset(br#"<meta charset="utf-32">"#), None);
 }
+
+#[test]
+fn content_type_charset_is_extracted_by_keyword_not_by_mime_parameter() {
+    // The algorithm searches for the keyword; it does not require a media
+    // type, and it does not parse MIME parameters.
+    assert_eq!(
+        sniff_html_meta_charset(br#"<meta http-equiv="content-type" content="charset=utf-8">"#)
+            .map(Encoding::name),
+        Some("UTF-8")
+    );
+    // The keyword is matched literally, including inside a longer word.
+    assert_eq!(
+        sniff_html_meta_charset(
+            br#"<meta http-equiv="content-type" content="text/html; xcharset=utf-8">"#
+        )
+        .map(Encoding::name),
+        Some("UTF-8")
+    );
+    // Whitespace is allowed on either side of the equals sign.
+    assert_eq!(
+        sniff_html_meta_charset(
+            br#"<meta http-equiv="content-type" content="text/html; charset = gbk">"#
+        )
+        .map(Encoding::name),
+        Some("GBK")
+    );
+}
+
+#[test]
+fn unquoted_content_type_charset_ends_at_whitespace_or_semicolon() {
+    assert_eq!(
+        sniff_html_meta_charset(
+            br#"<meta http-equiv="content-type" content="text/html; charset=utf-8 profile=x">"#
+        )
+        .map(Encoding::name),
+        Some("UTF-8")
+    );
+    assert_eq!(
+        sniff_html_meta_charset(
+            br#"<meta http-equiv="content-type" content="text/html; charset=utf-8;q=1">"#
+        )
+        .map(Encoding::name),
+        Some("UTF-8")
+    );
+}
+
+#[test]
+fn content_type_charset_requires_matching_quotes() {
+    for quoted in [
+        &br#"<meta http-equiv="content-type" content="text/html; charset='utf-8'">"#[..],
+        &br#"<meta http-equiv="content-type" content='text/html; charset="utf-8"'>"#[..],
+    ] {
+        assert_eq!(
+            sniff_html_meta_charset(quoted).map(Encoding::name),
+            Some("UTF-8")
+        );
+    }
+    // Opened but never closed contributes nothing, rather than being read to
+    // the end of the value.
+    assert_eq!(
+        sniff_html_meta_charset(
+            br#"<meta http-equiv="content-type" content='text/html; charset="utf-8'>"#
+        ),
+        None
+    );
+    // Opened with one quote and closed with the other is equally unmatched.
+    assert_eq!(
+        sniff_html_meta_charset(
+            br#"<meta http-equiv="content-type" content="text/html; charset=&quot;utf-8'">"#
+        ),
+        None
+    );
+}
+
+#[test]
+fn content_type_charset_search_resumes_after_a_bare_keyword() {
+    assert_eq!(
+        sniff_html_meta_charset(
+            br#"<meta http-equiv="content-type" content="charset; charset=gbk">"#
+        )
+        .map(Encoding::name),
+        Some("GBK")
+    );
+    assert_eq!(
+        sniff_html_meta_charset(br#"<meta http-equiv="content-type" content="charset">"#),
+        None
+    );
+}
+
+#[test]
+fn empty_content_type_charset_ends_the_extraction() {
+    // The algorithm returns the empty label it found; it does not keep
+    // searching the same value for a second assignment.
+    assert_eq!(
+        sniff_html_meta_charset(
+            br#"<meta http-equiv="content-type" content="text/html; charset=; charset=gbk">"#
+        ),
+        None
+    );
+}


### PR DESCRIPTION
Fixes #156.

`<meta http-equiv="Content-Type" content="...">` was parsed as a MIME parameter list — split on `;`, skip the media type, compare each parameter name for equality with `charset`, strip quotes with `trim_matches`. The HTML Standard specifies [a keyword search over the whole attribute value](https://html.spec.whatwg.org/multipage/parsing.html#algorithm-for-extracting-a-character-encoding-from-a-meta-element) instead, and the difference is observable in both directions.

A GBK page whose `content` attribute carries no media type, served without a charset header:

```html
<meta http-equiv="Content-Type" content="charset=gbk">
<p>家居</p>
```

```console
$ moli fetch --dump markdown http://127.0.0.1:8732/index.html   # before
¼Ò¾Ó

$ moli fetch --dump markdown http://127.0.0.1:8732/index.html   # after
家居
```

### What changed

| `content` value | before | after / spec |
| --- | --- | --- |
| `charset=utf-8` | *(none)* | UTF-8 |
| `text/html; charset=utf-8 profile=x` | *(none)* | UTF-8 |
| `text/html; xcharset=utf-8` | *(none)* | UTF-8 |
| `text/html; charset='utf-8` (unclosed) | UTF-8 | *(none)* |
| `text/html; charset="utf-8'` (mismatched) | UTF-8 | *(none)* |

`skip(1)` caused the first three: it required the label to sit in a parameter after a `;`, so a value with no media type never reached the comparison. `trim_matches` caused the last two: it strips any number of either quote from both ends, so an unmatched pair was accepted.

The implementation follows the algorithm directly — search for the literal `charset` from a moving position, allow whitespace either side of `=`, resume past a keyword that is not an assignment, and take a quoted label only when the same quote closes it, otherwise ending an unquoted label at the first ASCII whitespace or `;`.

### Two details for review

- The search resumes at the end of a non-assignment keyword, so `position` strictly advances and the loop cannot spin.
- Every byte index lands on an ASCII byte. ASCII bytes never occur inside a multi-byte UTF-8 sequence, so slicing the latin1-mapped prescan input stays on character boundaries.

### Behaviour change worth flagging

An empty label (`charset=;`) now ends the extraction rather than continuing to a later `charset=` in the same value. That follows step 6, which returns the label it found rather than resuming, and it is pinned by a test.

The pragma requirement is untouched: `content` is still only consulted when `http-equiv` is `content-type`, and `<meta charset>` still takes precedence.

### Verification

Per AGENTS.md, on aarch64-darwin:

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --no-fail-fast` — 16392 passed, 13 skipped, 7 failed

The 7 failures are pre-existing on 6f5aa320 and reproduce identically with this change reverted (`moli-webidl-callback` source-boundary ×2, `moli-core` window surface profile, `moli-layout` inline-block baseline, `moli-protocol` `scrollIntoViewIfNeeded` ×3). None touch charset handling. `moli-charset-parser` itself is 21/21.
