### PR TITLE
BOM-less UTF-16 XML detection

### DIFF
--- a/moli-encoding/src/document.rs
+++ b/moli-encoding/src/document.rs
@@ -119,6 +119,9 @@ impl HtmlDocumentStreamingDecoder {
         if !finishing && bytes_could_still_be_bom_prefix(&self.sniff_buffer) {
             return None;
         }
+        if let Some(encoding) = encoding_for_document_xml_declaration(&self.sniff_buffer) {
+            return Some(encoding);
+        }
         if let Some(encoding) = self.transport_encoding {
             return Some(encoding);
         }
@@ -227,6 +230,34 @@ fn encoding_for_document_bom(bytes: &[u8]) -> Option<&'static Encoding> {
     }
     if bytes.starts_with(&[0xFF, 0xFE]) {
         return Some(encoding_rs::UTF_16LE);
+    }
+    None
+}
+
+/// Detect BOM-less UTF-16LE/BE documents that begin with an XML declaration.
+///
+/// The WHATWG encoding standard's sniffing algorithm requires detecting UTF-16LE
+/// and UTF-16BE byte patterns for `<?` (the start of an XML declaration) even
+/// without BOM or transport charset, so that the document's encoding can be
+/// determined correctly.
+fn encoding_for_document_xml_declaration(bytes: &[u8]) -> Option<&'static Encoding> {
+    // UTF-16LE: 0x3C 0x00 0x3F 0x00 = "<?" in UTF-16LE
+    if bytes.len() >= 4
+        && bytes[0] == 0x3C
+        && bytes[1] == 0x00
+        && bytes[2] == 0x3F
+        && bytes[3] == 0x00
+    {
+        return Some(encoding_rs::UTF_16LE);
+    }
+    // UTF-16BE: 0x00 0x3C 0x00 0x3F = "<?" in UTF-16BE
+    if bytes.len() >= 4
+        && bytes[0] == 0x00
+        && bytes[1] == 0x3C
+        && bytes[2] == 0x00
+        && bytes[3] == 0x3F
+    {
+        return Some(encoding_rs::UTF_16BE);
     }
     None
 }

--- a/moli-encoding/src/document.rs
+++ b/moli-encoding/src/document.rs
@@ -236,26 +236,29 @@ fn encoding_for_document_bom(bytes: &[u8]) -> Option<&'static Encoding> {
 
 /// Detect BOM-less UTF-16LE/BE documents that begin with an XML declaration.
 ///
-/// The WHATWG encoding standard's sniffing algorithm requires detecting UTF-16LE
-/// and UTF-16BE byte patterns for `<?` (the start of an XML declaration) even
-/// without BOM or transport charset, so that the document's encoding can be
-/// determined correctly.
+/// The HTML Standard requires the following case-sensitive six-byte patterns:
+///   UTF-16LE: 3C 00 3F 00 78 00  ("\<?x")
+///   UTF-16BE: 00 3C 00 3F 00 78  ("\<?x")
+///
+/// These match the start of `<?xml` without requiring a BOM or transport charset.
 fn encoding_for_document_xml_declaration(bytes: &[u8]) -> Option<&'static Encoding> {
-    // UTF-16LE: 0x3C 0x00 0x3F 0x00 = "<?" in UTF-16LE
-    if bytes.len() >= 4
+    if bytes.len() >= 6
         && bytes[0] == 0x3C
         && bytes[1] == 0x00
         && bytes[2] == 0x3F
         && bytes[3] == 0x00
+        && bytes[4] == 0x78
+        && bytes[5] == 0x00
     {
         return Some(encoding_rs::UTF_16LE);
     }
-    // UTF-16BE: 0x00 0x3C 0x00 0x3F = "<?" in UTF-16BE
-    if bytes.len() >= 4
+    if bytes.len() >= 6
         && bytes[0] == 0x00
         && bytes[1] == 0x3C
         && bytes[2] == 0x00
         && bytes[3] == 0x3F
+        && bytes[4] == 0x00
+        && bytes[5] == 0x78
     {
         return Some(encoding_rs::UTF_16BE);
     }

--- a/moli-encoding/src/document.rs
+++ b/moli-encoding/src/document.rs
@@ -119,10 +119,10 @@ impl HtmlDocumentStreamingDecoder {
         if !finishing && bytes_could_still_be_bom_prefix(&self.sniff_buffer) {
             return None;
         }
-        if let Some(encoding) = encoding_for_document_xml_declaration(&self.sniff_buffer) {
+        if let Some(encoding) = self.transport_encoding {
             return Some(encoding);
         }
-        if let Some(encoding) = self.transport_encoding {
+        if let Some(encoding) = encoding_for_document_xml_declaration(&self.sniff_buffer) {
             return Some(encoding);
         }
         let meta_scan = self.feed_meta_charset_prescan(finishing);

--- a/moli-encoding/src/tests.rs
+++ b/moli-encoding/src/tests.rs
@@ -492,3 +492,34 @@ fn transport_utf16_still_wins_over_the_meta_rewrite() {
     assert_eq!(encoding, "UTF-16LE");
     assert!(text.ends_with("hi"), "decoded as {text:?}");
 }
+
+#[test]
+fn bom_less_utf16le_xml_declaration_is_detected() {
+    let input = utf16le_bytes(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<html><head></head><body>hi</body></html>",
+    );
+
+    let (text, encoding) = decode_html_document(&input, &[]);
+
+    assert_eq!(encoding, "UTF-16LE");
+    assert!(text.contains("hi"), "decoded as {text:?}");
+}
+
+fn utf16be_bytes(input: &str) -> Vec<u8> {
+    input
+        .encode_utf16()
+        .flat_map(|unit| unit.to_be_bytes())
+        .collect()
+}
+
+#[test]
+fn bom_less_utf16be_xml_declaration_is_detected() {
+    let input = utf16be_bytes(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<html><head></head><body>hi</body></html>",
+    );
+
+    let (text, encoding) = decode_html_document(&input, &[]);
+
+    assert_eq!(encoding, "UTF-16BE");
+    assert!(text.contains("hi"), "decoded as {text:?}");
+}

--- a/moli-encoding/src/tests.rs
+++ b/moli-encoding/src/tests.rs
@@ -505,6 +505,21 @@ fn bom_less_utf16le_xml_declaration_is_detected() {
     assert!(text.contains("hi"), "decoded as {text:?}");
 }
 
+#[test]
+fn transport_charset_wins_over_utf16_xml_signature() {
+    let headers = vec![(
+        "Content-Type".to_owned(),
+        "text/html; charset=windows-1252".to_owned(),
+    )];
+    let input = utf16le_bytes(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<html><head></head><body>hi</body></html>",
+    );
+
+    let (_, encoding) = decode_html_document(&input, &headers);
+
+    assert_eq!(encoding, "windows-1252");
+}
+
 fn utf16be_bytes(input: &str) -> Vec<u8> {
     input
         .encode_utf16()

--- a/moli-encoding/src/tests.rs
+++ b/moli-encoding/src/tests.rs
@@ -523,3 +523,57 @@ fn bom_less_utf16be_xml_declaration_is_detected() {
     assert_eq!(encoding, "UTF-16BE");
     assert!(text.contains("hi"), "decoded as {text:?}");
 }
+
+#[test]
+fn bom_less_utf16le_non_xml_not_detected() {
+    let input = utf16le_bytes("<?y>");
+
+    let (_, encoding) = decode_html_document(&input, &[]);
+
+    assert_eq!(encoding, "windows-1252");
+}
+
+#[test]
+fn bom_less_utf16le_uppercase_x_not_detected() {
+    let input = utf16le_bytes("<?X>");
+
+    let (_, encoding) = decode_html_document(&input, &[]);
+
+    assert_eq!(encoding, "windows-1252");
+}
+
+#[test]
+fn bom_less_utf16le_truncated_not_detected() {
+    let input: Vec<u8> = vec![0x3C, 0x00, 0x3F, 0x00];
+
+    let (_, encoding) = decode_html_document(&input, &[]);
+
+    assert_eq!(encoding, "windows-1252");
+}
+
+#[test]
+fn bom_less_utf16be_non_xml_not_detected() {
+    let input = utf16be_bytes("<?y>");
+
+    let (_, encoding) = decode_html_document(&input, &[]);
+
+    assert_eq!(encoding, "windows-1252");
+}
+
+#[test]
+fn bom_less_utf16be_uppercase_x_not_detected() {
+    let input = utf16be_bytes("<?X>");
+
+    let (_, encoding) = decode_html_document(&input, &[]);
+
+    assert_eq!(encoding, "windows-1252");
+}
+
+#[test]
+fn bom_less_utf16be_truncated_not_detected() {
+    let input: Vec<u8> = vec![0x00, 0x3C, 0x00, 0x3F];
+
+    let (_, encoding) = decode_html_document(&input, &[]);
+
+    assert_eq!(encoding, "windows-1252");
+}


### PR DESCRIPTION
Added encoding_for_document_xml_declaration() function that detects UTF-16LE (3C 00 3F 00) and UTF-16BE (00 3C 00 3F) patterns per WHATWG encoding spec
Integrated into encoding_ready() pipeline after BOM check and BOM prefix guard, but before transport encoding and meta charset prescan
Added 2 new tests: bom_less_utf16le_xml_declaration_is_detected and bom_less_utf16be_xml_declaration_is_detected