### PR TITLE
Reject invalid --block-cidrs entries

### DIFF
--- a/moli/src/config.rs
+++ b/moli/src/config.rs
@@ -182,7 +182,7 @@ fn apply_common_args(config: &mut AppConfig, common: &CommonArgs) -> Result<()> 
     config.fetch.cookie_files = common.cookie_file.clone();
     config.browser.fetch_mut().set_network_blocking(
         common.block_private_networks,
-        parse_block_cidrs(common.block_cidrs.as_deref()),
+        parse_block_cidrs(common.block_cidrs.as_deref())?,
     );
     config
         .browser
@@ -257,16 +257,22 @@ fn validate_http_host_resolve_entry(entry: &str) -> Result<()> {
     Ok(())
 }
 
-fn parse_block_cidrs(raw: Option<&str>) -> Vec<AnyIpCidr> {
-    raw.into_iter()
-        .flat_map(|value| value.split(','))
-        .filter_map(|item| {
-            let trimmed = item.trim();
-            (!trimmed.is_empty())
-                .then(|| AnyIpCidr::from_str(trimmed).ok())
-                .flatten()
-        })
-        .collect()
+fn parse_block_cidrs(raw: Option<&str>) -> Result<Vec<AnyIpCidr>> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+
+    let mut cidrs = Vec::new();
+    for item in raw.split(',').map(str::trim) {
+        if item.is_empty() {
+            bail!("--block-cidrs entries must not be empty");
+        }
+        cidrs.push(
+            AnyIpCidr::from_str(item)
+                .with_context(|| format!("invalid --block-cidrs entry `{item}`"))?,
+        );
+    }
+    Ok(cidrs)
 }
 
 impl Default for AppConfig {

--- a/moli/tests/cli.rs
+++ b/moli/tests/cli.rs
@@ -1184,6 +1184,66 @@ fn app_config_rejects_invalid_http_host_resolve_entry() {
 }
 
 #[test]
+fn app_config_from_cli_applies_block_cidrs() {
+    let cli = Cli::try_parse_from(normalize_args_for_compat([
+        "moli",
+        "fetch",
+        "--block-cidrs",
+        "198.18.0.0/15, 203.0.113.0/24",
+        "https://example.com",
+    ]))
+    .unwrap();
+
+    let config = AppConfig::from_cli(&cli).unwrap();
+    let cidrs = config.browser.fetch().block_cidrs();
+    assert_eq!(cidrs.len(), 2);
+    assert_eq!(cidrs[0].to_string(), "198.18.0.0/15");
+    assert_eq!(cidrs[1].to_string(), "203.0.113.0/24");
+}
+
+#[test]
+fn app_config_rejects_invalid_block_cidr_entry() {
+    let cli = Cli::try_parse_from(normalize_args_for_compat([
+        "moli",
+        "fetch",
+        "--block-cidrs",
+        "198.18.0.0/15,not-a-cidr",
+        "https://example.com",
+    ]))
+    .unwrap();
+
+    let error = AppConfig::from_cli(&cli).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("invalid --block-cidrs entry `not-a-cidr`"),
+        "{error:#}"
+    );
+}
+
+#[test]
+fn app_config_rejects_empty_block_cidr_entries() {
+    for raw in ["", "198.18.0.0/15,", ",198.18.0.0/15"] {
+        let cli = Cli::try_parse_from(normalize_args_for_compat([
+            "moli",
+            "fetch",
+            "--block-cidrs",
+            raw,
+            "https://example.com",
+        ]))
+        .unwrap();
+
+        let error = AppConfig::from_cli(&cli).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("--block-cidrs entries must not be empty"),
+            "{error:#}"
+        );
+    }
+}
+
+#[test]
 fn removed_cookie_cache_flag_is_rejected() {
     let error = Cli::try_parse_from(normalize_args_for_compat([
         "moli",

--- a/skills/moli-cdp-server/references/protocols.md
+++ b/skills/moli-cdp-server/references/protocols.md
@@ -51,7 +51,8 @@ hard-coding a `/devtools/...` path.
 - Add `--profile-dir` for persistent storage and cookies.
 - Add `--cookie-file` to import cookies.
 - Configure proxy and connection controls on `moli serve`.
-- Add `--block-private-networks` or `--block-cidrs` for untrusted navigation.
+- Add `--block-private-networks` or a comma-separated `--block-cidrs` list for
+  untrusted navigation; invalid or empty CIDR entries are rejected.
 - Keep loopback binding unless remote clients genuinely require exposure.
 
 ## Full-document screenshots

--- a/skills/moli-webfetch/references/fetch-recipes.md
+++ b/skills/moli-webfetch/references/fetch-recipes.md
@@ -158,7 +158,8 @@ For a crawl rather than a single lookup:
 - Use `--document-start-script` or `--document-start-script-file` only when the
   task explicitly requires pre-navigation instrumentation.
 - Combine `--block-private-networks` with `--block-cidrs` for untrusted URL
-  workloads that need explicit network boundaries.
+  workloads that need explicit network boundaries. Pass `--block-cidrs` as a
+  comma-separated list of CIDR ranges; invalid or empty entries are rejected.
 
 ## Failure Diagnosis
 


### PR DESCRIPTION
## Summary

Make --block-cidrs fail fast instead of silently dropping malformed or empty CIDR entries.

The previous parser accepted the flag, discarded invalid items, and could leave network boundary controls disabled without telling the operator. This is especially risky for untrusted navigation workloads that rely on block-cidrs as an SSRF / private-network guard.

## Changes

- Validate each comma-separated CIDR entry in AppConfig::from_cli
- Return a structured error for invalid or empty entries
- Add regression tests for valid input, invalid input, and empty entries
- Clarify the flag in the webfetch and CDP protocol guidance docs

## Verification

- cargo fmt --all
- git diff --check
- cd moli-frontend-smoke && uv run pytest -q
- cd moli-frontend-smoke && npm run test:node -- --test-reporter=spec
- cd moli-cdp-smoke && uv run --with pytest pytest -q
- cd moli-webdriver-smoke && uv run --with pytest pytest -q

Notes:

- cargo clippy --workspace --all-targets --all-features -- -D warnings was started, but this environment stalled on dependency downloads before reaching analysis.
- cargo nextest run --no-fail-fast requires cargo-nextest; installing cargo-nextest was also blocked by slow dependency downloads in this environment.
