### PR TITLE
fix(fetch): honor host-resolve overrides in network blocking

### DIFF
--- a/moli-fetch/src/blocking/mod.rs
+++ b/moli-fetch/src/blocking/mod.rs
@@ -693,9 +693,9 @@ pub(crate) fn configure_easy<H: Handler>(
     }
     if !config.http_host_resolve().is_empty() {
         let mut resolve = List::new();
-        for entry in config.http_host_resolve() {
+        for entry in normalized_http_host_resolve_entries(config.http_host_resolve())? {
             resolve
-                .append(entry)
+                .append(&entry)
                 .with_context(|| anyhow!("failed to build curl host resolve entry `{entry}`"))?;
         }
         easy.resolve(resolve)
@@ -842,14 +842,14 @@ fn enforce_request_target_policy(config: &FetchConfig, request_url: &Url) -> Res
 }
 
 fn resolve_target_ips(config: &FetchConfig, host: &str, port: u16) -> Result<Vec<IpAddr>> {
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        return Ok(vec![ip]);
-    }
-
     if let Some(resolved_ips) =
         resolve_host_resolve_override_ips(config.http_host_resolve(), host, port)?
     {
         return Ok(resolved_ips);
+    }
+
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return Ok(vec![ip]);
     }
 
     resolve_system_target_ips(host, port)
@@ -868,6 +868,7 @@ fn resolve_host_resolve_override_ips(
                 host: entry_host,
                 port: entry_port,
                 addresses,
+                ..
             } if entry_port == port => {
                 if entry_host == "*" {
                     wildcard_match = Some(addresses);
@@ -908,6 +909,7 @@ fn resolve_system_target_ips(host: &str, port: u16) -> Result<Vec<IpAddr>> {
 
 enum HttpHostResolveEntry {
     Add {
+        plus_prefix: bool,
         host: String,
         port: u16,
         addresses: Vec<IpAddr>,
@@ -916,6 +918,40 @@ enum HttpHostResolveEntry {
         host: String,
         port: u16,
     },
+}
+
+impl HttpHostResolveEntry {
+    fn curl_entry(&self) -> String {
+        match self {
+            Self::Add {
+                plus_prefix,
+                host,
+                port,
+                addresses,
+            } => {
+                let prefix = if *plus_prefix { "+" } else { "" };
+                let addresses = addresses
+                    .iter()
+                    .map(format_http_host_resolve_ip)
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!(
+                    "{prefix}{}:{port}:{addresses}",
+                    format_http_host_resolve_host(host)
+                )
+            }
+            Self::Remove { host, port } => {
+                format!("-{}:{port}", format_http_host_resolve_host(host))
+            }
+        }
+    }
+}
+
+fn normalized_http_host_resolve_entries(entries: &[String]) -> Result<Vec<String>> {
+    entries
+        .iter()
+        .map(|entry| parse_http_host_resolve_entry(entry).map(|entry| entry.curl_entry()))
+        .collect()
 }
 
 fn parse_http_host_resolve_entry(entry: &str) -> Result<HttpHostResolveEntry> {
@@ -928,7 +964,11 @@ fn parse_http_host_resolve_entry(entry: &str) -> Result<HttpHostResolveEntry> {
         });
     }
 
-    let entry = entry.strip_prefix('+').unwrap_or(entry);
+    let (plus_prefix, entry) = if let Some(entry) = entry.strip_prefix('+') {
+        (true, entry)
+    } else {
+        (false, entry)
+    };
     let (host, port, address) = split_http_host_resolve_add_entry(entry)?;
     let port = parse_http_host_resolve_port(port, entry)?;
     let mut addresses = Vec::new();
@@ -946,6 +986,7 @@ fn parse_http_host_resolve_entry(entry: &str) -> Result<HttpHostResolveEntry> {
     }
 
     Ok(HttpHostResolveEntry::Add {
+        plus_prefix,
         host: normalize_http_host_resolve_host(host),
         port,
         addresses,
@@ -1014,7 +1055,22 @@ fn parse_http_host_resolve_port(port: &str, entry: &str) -> Result<u16> {
 }
 
 fn normalize_http_host_resolve_host(host: &str) -> String {
-    host.trim_matches(['[', ']', '+']).to_owned()
+    host.trim_matches(['[', ']']).to_owned()
+}
+
+fn format_http_host_resolve_host(host: &str) -> String {
+    if host != "*" && host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host.to_owned()
+    }
+}
+
+fn format_http_host_resolve_ip(ip: &IpAddr) -> String {
+    match ip {
+        IpAddr::V4(ip) => ip.to_string(),
+        IpAddr::V6(ip) => format!("[{ip}]"),
+    }
 }
 
 fn is_private_or_internal_ip(ip: IpAddr) -> bool {
@@ -1548,6 +1604,23 @@ mod tests {
         );
         assert!(header_value(&headers, "accept").is_some());
         assert!(header_value(&headers, "sec-ch-ua").is_some());
+    }
+
+    #[test]
+    fn http_host_resolve_entries_are_normalized_before_curl_configuration() {
+        let entries = normalized_http_host_resolve_entries(&[
+            " localhost:80: 1.1.1.1 , [2001:db8::1] ".to_owned(),
+            " - localhost:80 ".to_owned(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            entries,
+            vec![
+                "localhost:80:1.1.1.1,[2001:db8::1]".to_owned(),
+                "-localhost:80".to_owned()
+            ]
+        );
     }
 
     #[test]

--- a/moli-fetch/src/blocking/mod.rs
+++ b/moli-fetch/src/blocking/mod.rs
@@ -827,7 +827,7 @@ fn enforce_request_target_policy(config: &FetchConfig, request_url: &Url) -> Res
         .port_or_known_default()
         .ok_or_else(|| anyhow!("could not determine port for request url `{request_url}`"))?;
 
-    let resolved_ips = resolve_target_ips(host, port)
+    let resolved_ips = resolve_target_ips(config, host, port)
         .with_context(|| anyhow!("failed to resolve request host `{host}` for `{request_url}`"))?;
     for ip in resolved_ips {
         if config.block_private_networks() && is_private_or_internal_ip(ip) {
@@ -841,11 +841,58 @@ fn enforce_request_target_policy(config: &FetchConfig, request_url: &Url) -> Res
     Ok(())
 }
 
-fn resolve_target_ips(host: &str, port: u16) -> Result<Vec<IpAddr>> {
+fn resolve_target_ips(config: &FetchConfig, host: &str, port: u16) -> Result<Vec<IpAddr>> {
     if let Ok(ip) = host.parse::<IpAddr>() {
         return Ok(vec![ip]);
     }
 
+    if let Some(resolved_ips) =
+        resolve_host_resolve_override_ips(config.http_host_resolve(), host, port)?
+    {
+        return Ok(resolved_ips);
+    }
+
+    resolve_system_target_ips(host, port)
+}
+
+fn resolve_host_resolve_override_ips(
+    entries: &[String],
+    host: &str,
+    port: u16,
+) -> Result<Option<Vec<IpAddr>>> {
+    let mut exact_match: Option<Vec<IpAddr>> = None;
+    let mut wildcard_match: Option<Vec<IpAddr>> = None;
+    for entry in entries {
+        match parse_http_host_resolve_entry(entry)? {
+            HttpHostResolveEntry::Add {
+                host: entry_host,
+                port: entry_port,
+                addresses,
+            } if entry_port == port => {
+                if entry_host == "*" {
+                    wildcard_match = Some(addresses);
+                } else if entry_host.eq_ignore_ascii_case(host) {
+                    exact_match = Some(addresses);
+                }
+            }
+            HttpHostResolveEntry::Remove {
+                host: entry_host,
+                port: entry_port,
+            } if entry_port == port => {
+                if entry_host == "*" {
+                    wildcard_match = None;
+                } else if entry_host.eq_ignore_ascii_case(host) {
+                    exact_match = None;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(exact_match.or(wildcard_match))
+}
+
+fn resolve_system_target_ips(host: &str, port: u16) -> Result<Vec<IpAddr>> {
     let mut resolved = Vec::new();
     for addr in (host, port).to_socket_addrs()? {
         let ip = addr.ip();
@@ -857,6 +904,117 @@ fn resolve_target_ips(host: &str, port: u16) -> Result<Vec<IpAddr>> {
         bail!("no addresses resolved");
     }
     Ok(resolved)
+}
+
+enum HttpHostResolveEntry {
+    Add {
+        host: String,
+        port: u16,
+        addresses: Vec<IpAddr>,
+    },
+    Remove {
+        host: String,
+        port: u16,
+    },
+}
+
+fn parse_http_host_resolve_entry(entry: &str) -> Result<HttpHostResolveEntry> {
+    let entry = entry.trim();
+    if let Some(entry) = entry.strip_prefix('-') {
+        let (host, port) = split_http_host_resolve_remove_entry(entry)?;
+        return Ok(HttpHostResolveEntry::Remove {
+            host: normalize_http_host_resolve_host(host),
+            port: parse_http_host_resolve_port(port, entry)?,
+        });
+    }
+
+    let entry = entry.strip_prefix('+').unwrap_or(entry);
+    let (host, port, address) = split_http_host_resolve_add_entry(entry)?;
+    let port = parse_http_host_resolve_port(port, entry)?;
+    let mut addresses = Vec::new();
+    for address in address.split(',').map(str::trim) {
+        if address.is_empty() {
+            bail!("--http-host-resolve entries must not contain empty addresses");
+        }
+        let address = address.trim_matches(['[', ']']);
+        let address = address
+            .parse::<IpAddr>()
+            .with_context(|| format!("invalid --http-host-resolve address in `{entry}`"))?;
+        if !addresses.contains(&address) {
+            addresses.push(address);
+        }
+    }
+
+    Ok(HttpHostResolveEntry::Add {
+        host: normalize_http_host_resolve_host(host),
+        port,
+        addresses,
+    })
+}
+
+fn split_http_host_resolve_add_entry(entry: &str) -> Result<(&str, &str, &str)> {
+    if let Some(entry) = entry.strip_prefix('[') {
+        let Some(host_end) = entry.find(']') else {
+            bail!("--http-host-resolve must be in HOST:PORT:ADDR form");
+        };
+        let host = &entry[..host_end];
+        let remainder = &entry[host_end + 1..];
+        let Some(remainder) = remainder.strip_prefix(':') else {
+            bail!("--http-host-resolve must be in HOST:PORT:ADDR form");
+        };
+        let Some((port, address)) = remainder.split_once(':') else {
+            bail!("--http-host-resolve must be in HOST:PORT:ADDR form");
+        };
+        if host.trim().is_empty() || port.trim().is_empty() || address.trim().is_empty() {
+            bail!("--http-host-resolve must be in HOST:PORT:ADDR form");
+        }
+        return Ok((host.trim(), port.trim(), address.trim()));
+    }
+
+    let mut parts = entry.splitn(3, ':');
+    let host = parts.next().unwrap_or_default().trim();
+    let port = parts.next().unwrap_or_default().trim();
+    let address = parts.next().unwrap_or_default().trim();
+
+    if host.is_empty() || port.is_empty() || address.is_empty() {
+        bail!("--http-host-resolve must be in HOST:PORT:ADDR form");
+    }
+
+    Ok((host, port, address))
+}
+
+fn split_http_host_resolve_remove_entry(entry: &str) -> Result<(&str, &str)> {
+    if let Some(entry) = entry.strip_prefix('[') {
+        let Some(host_end) = entry.find(']') else {
+            bail!("--http-host-resolve removal must be in HOST:PORT form");
+        };
+        let host = &entry[..host_end];
+        let remainder = &entry[host_end + 1..];
+        let Some(port) = remainder.strip_prefix(':') else {
+            bail!("--http-host-resolve removal must be in HOST:PORT form");
+        };
+        if host.trim().is_empty() || port.trim().is_empty() {
+            bail!("--http-host-resolve removal must be in HOST:PORT form");
+        }
+        return Ok((host.trim(), port.trim()));
+    }
+
+    let Some((host, port)) = entry.split_once(':') else {
+        bail!("--http-host-resolve removal must be in HOST:PORT form");
+    };
+    if host.trim().is_empty() || port.trim().is_empty() {
+        bail!("--http-host-resolve removal must be in HOST:PORT form");
+    }
+    Ok((host.trim(), port.trim()))
+}
+
+fn parse_http_host_resolve_port(port: &str, entry: &str) -> Result<u16> {
+    port.parse::<u16>()
+        .with_context(|| format!("invalid --http-host-resolve port in `{entry}`"))
+}
+
+fn normalize_http_host_resolve_host(host: &str) -> String {
+    host.trim_matches(['[', ']', '+']).to_owned()
 }
 
 fn is_private_or_internal_ip(ip: IpAddr) -> bool {

--- a/moli-fetch/src/tests/mod.rs
+++ b/moli-fetch/src/tests/mod.rs
@@ -1815,6 +1815,34 @@ fn fetch_client_rejects_private_network_targets_via_host_resolve_override() {
 }
 
 #[test]
+fn fetch_client_rejects_ip_literal_private_target_via_host_resolve_override() {
+    let server = ScriptedHttpServer::spawn(vec![ScriptedResponse::ok("should-not-be-reached")]);
+    let port = Url::parse(&server.url())
+        .unwrap()
+        .port()
+        .expect("scripted server URL should include a port");
+    let mut config = FetchConfig::default();
+    config.set_http_proxy(Some(String::new()));
+    config.set_network_blocking(true, vec![]);
+    config.set_http_host_resolve(vec![format!("1.1.1.1:{port}:127.0.0.1")]);
+
+    let error = fetch_with_config_for_test(
+        &config,
+        Request::get(&format!("http://1.1.1.1:{port}/")).unwrap(),
+    )
+    .unwrap_err();
+    let error_chain = format!("{error:#}");
+
+    assert!(
+        error_chain.contains("blocked private network address `127.0.0.1`"),
+        "unexpected error: {error_chain}"
+    );
+    assert_eq!(server.hits(), 0);
+
+    server.shutdown();
+}
+
+#[test]
 fn fetch_client_rejects_configured_cidrs() {
     let mut config = FetchConfig::default();
     config.set_network_blocking(false, vec!["198.18.0.0/15".parse().unwrap()]);

--- a/moli-fetch/src/tests/mod.rs
+++ b/moli-fetch/src/tests/mod.rs
@@ -1787,6 +1787,34 @@ fn fetch_client_rejects_private_network_targets() {
 }
 
 #[test]
+fn fetch_client_rejects_private_network_targets_via_host_resolve_override() {
+    let server = ScriptedHttpServer::spawn(vec![ScriptedResponse::ok("should-not-be-reached")]);
+    let port = Url::parse(&server.url())
+        .unwrap()
+        .port()
+        .expect("scripted server URL should include a port");
+    let mut config = FetchConfig::default();
+    config.set_http_proxy(Some(String::new()));
+    config.set_network_blocking(true, vec![]);
+    config.set_http_host_resolve(vec![format!("example.com:{port}:127.0.0.1")]);
+
+    let error = fetch_with_config_for_test(
+        &config,
+        Request::get(&format!("http://example.com:{port}/")).unwrap(),
+    )
+    .unwrap_err();
+    let error_chain = format!("{error:#}");
+
+    assert!(
+        error_chain.contains("blocked private network address `127.0.0.1`"),
+        "unexpected error: {error_chain}"
+    );
+    assert_eq!(server.hits(), 0);
+
+    server.shutdown();
+}
+
+#[test]
 fn fetch_client_rejects_configured_cidrs() {
     let mut config = FetchConfig::default();
     config.set_network_blocking(false, vec!["198.18.0.0/15".parse().unwrap()]);


### PR DESCRIPTION
## Summary
- make network blocking evaluate the actual host-resolve destination before curl opens a transfer
- cover private-network blocking when a public hostname is mapped to localhost via http_host_resolve
- support curl-style host-resolve add/remove, wildcard, and bracketed host forms in the policy parser

## Why
When users combine `--block-private-networks` with `--http-host-resolve`, Moli checked the URL hostname before curl applied the host-resolve override. A request like `http://example.com:<port>/` could therefore pass policy while curl connected to `127.0.0.1:<port>`, bypassing the private-network guard.

## Tests
- `cargo fmt --all`
- `cargo test -p moli-fetch fetch_client_rejects_private_network_targets_via_host_resolve_override -- --nocapture`
- `cargo test -p moli-fetch fetch_client_rejects_ -- --nocapture`
- `cargo test -p moli-fetch --lib`

## Notes
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo nextest run --no-fail-fast` are currently blocked in this local environment because Rust 1.95.0 rejects workspace dependencies requiring Rust 1.96.0 (`vergen` 10.0.2 family).
