### PR TITLE
fix(doc): correct windows powershell install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl --proto '=https' --tlsv1.2 -fsSL \
 On Windows, run in PowerShell:
 
 ```powershell
-irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex"
 ```
 
 ## Showcase

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -48,7 +48,7 @@ curl --proto '=https' --tlsv1.2 -fsSL \
 Unter Windows in PowerShell ausführen:
 
 ```powershell
-irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex"
 ```
 
 ## Demo

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -48,7 +48,7 @@ curl --proto '=https' --tlsv1.2 -fsSL \
 En Windows, ejecuta este comando en PowerShell:
 
 ```powershell
-irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex"
 ```
 
 ## Demostración

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -48,7 +48,7 @@ curl --proto '=https' --tlsv1.2 -fsSL \
 Sous Windows, exécutez cette commande dans PowerShell :
 
 ```powershell
-irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex"
 ```
 
 ## Démonstration

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -47,7 +47,7 @@ curl --proto '=https' --tlsv1.2 -fsSL \
 Windows の場合は、PowerShell で次のコマンドを実行します：
 
 ```powershell
-irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex"
 ```
 
 ## 動作例

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -47,7 +47,7 @@ curl --proto '=https' --tlsv1.2 -fsSL \
 在 Windows 上，请在 PowerShell 中运行：
 
 ```powershell
-irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex"
 ```
 
 ## 效果展示

--- a/skills/moli-cdp-server/SKILL.md
+++ b/skills/moli-cdp-server/SKILL.md
@@ -23,7 +23,7 @@ Preserve the client's existing API where Moli supports it.
    On Windows, use PowerShell:
 
    ```powershell
-   irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex
+   powershell -ExecutionPolicy ByPass -c "irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex"
    ```
 
    Resolve the installed binary again and run `moli --version`. The default

--- a/skills/moli-webfetch/SKILL.md
+++ b/skills/moli-webfetch/SKILL.md
@@ -24,7 +24,7 @@ structure-first; enable layout only when the result needs pixels or pagination.
    On Windows, use PowerShell:
 
    ```powershell
-   irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex
+   powershell -ExecutionPolicy ByPass -c "irm https://github.com/lexmount/moli/releases/latest/download/moli-installer.ps1 | iex"
    ```
 
    Resolve the installed binary again and run `moli --version`. The default


### PR DESCRIPTION
Currently installing moli on Windows may fail. The fixed was inspired by codex: https://github.com/openai/codex#quickstart