### PR TITLE
fix(cookies): make host-only cookies port-agnostic per RFC 6265

### DIFF
--- a/moli-cookie-jar/src/tests.rs
+++ b/moli-cookie-jar/src/tests.rs
@@ -3869,7 +3869,7 @@ fn request_access_report_projects_browser_site_context_snapshot() {
 }
 
 #[test]
-fn request_access_report_projects_source_port_mismatch_exclusion() {
+fn request_access_report_is_agnostic_to_source_port() {
     let mut store = BrowserCookieStore::default();
     let response_url = parse("https://example.com:8443/app/index.html");
     let request_url = parse("https://example.com:9443/app/panel");
@@ -3882,15 +3882,35 @@ fn request_access_report_projects_source_port_mismatch_exclusion() {
         )],
     );
 
+    // RFC 6265 matching is port-agnostic: a cookie set on one port of a host
+    // is attached to requests on every other port of the same host.
     let report = store.cookie_access_report_for_request(
         &request_url,
         NetworkCookieRequestContext::subresource("GET"),
     );
     let sid = find_cookie(&report, "sid").expect("cookie should be present");
-    assert_eq!(
-        sid.exclusion_reasons,
-        vec![StoredCookieExclusionReason::PortMismatch]
+    assert_eq!(sid.exclusion_reasons, vec![]);
+    assert!(
+        report
+            .included_cookies
+            .iter()
+            .any(|entry| entry.cookie.name == "sid")
     );
+}
+
+#[test]
+fn host_only_cookie_is_shared_across_ports_of_the_same_host() {
+    let mut store = BrowserCookieStore::default();
+    let set_url = parse("http://127.0.0.1:8771/");
+    let other_port_url = parse("http://127.0.0.1:8768/check");
+
+    store.store_response_headers(
+        &set_url,
+        &[("set-cookie".to_owned(), "a=1; Path=/".to_owned())],
+    );
+
+    assert_eq!(store.document_cookie(&other_port_url), "a=1");
+    assert_eq!(store.cookie_header(&other_port_url).as_deref(), Some("a=1"));
 }
 
 #[test]
@@ -3940,7 +3960,6 @@ fn request_access_report_accumulates_multiple_exclusion_reasons() {
         vec![
             StoredCookieExclusionReason::PathMismatch,
             StoredCookieExclusionReason::SecureOnly,
-            StoredCookieExclusionReason::PortMismatch,
             StoredCookieExclusionReason::SchemeMismatch,
             StoredCookieExclusionReason::SameSiteStrict,
         ]
@@ -4001,7 +4020,6 @@ fn request_access_report_projects_access_semantics_and_secure_access_capability(
         strict_insecure.exclusion_reasons,
         vec![
             StoredCookieExclusionReason::SecureOnly,
-            StoredCookieExclusionReason::PortMismatch,
             StoredCookieExclusionReason::SchemeMismatch,
         ]
     );

--- a/moli-cookie-store/src/cookie_store/policy.rs
+++ b/moli-cookie-store/src/cookie_store/policy.rs
@@ -8,15 +8,6 @@ use crate::utils::is_http_scheme;
 
 use super::*;
 
-pub(super) fn source_port_mismatch(cookie: &Cookie<'_>, url: &Url) -> bool {
-    let source_port = cookie.source_port();
-    source_port != -1
-        && url
-            .port_or_known_default()
-            .map(i32::from)
-            .is_some_and(|request_port| request_port != source_port)
-}
-
 pub(super) fn source_scheme_mismatch(cookie: &Cookie<'_>, url: &Url) -> bool {
     let source_scheme = cookie.source_scheme();
     source_scheme != CookieSourceScheme::Unset && source_scheme != CookieSourceScheme::from_url(url)

--- a/moli-cookie-store/src/cookie_store/query_policy.rs
+++ b/moli-cookie-store/src/cookie_store/query_policy.rs
@@ -4,8 +4,7 @@ use crate::cookie::Cookie;
 use crate::utils::{is_http_scheme, is_secure, is_trustworthy_non_cryptographic};
 
 use super::policy::{
-    access_semantics, effective_same_site, scope_semantics, source_port_mismatch,
-    source_scheme_mismatch,
+    access_semantics, effective_same_site, scope_semantics, source_scheme_mismatch,
 };
 use super::*;
 
@@ -64,9 +63,6 @@ pub(super) fn query_context_access_result(
         && !is_http_scheme(context.url)
     {
         status.add_exclusion(CookieExclusionReason::HttpOnly);
-    }
-    if source_port_mismatch(cookie, context.url) {
-        status.add_exclusion(CookieExclusionReason::PortMismatch);
     }
     if source_scheme_mismatch(cookie, context.url) {
         status.add_exclusion(CookieExclusionReason::SchemeMismatch);

--- a/moli-cookie-store/src/cookie_store/tests/query_filter.rs
+++ b/moli-cookie-store/src/cookie_store/tests/query_filter.rs
@@ -136,24 +136,38 @@ fn query_result_reports_secure_and_path_exclusions() {
 }
 
 #[test]
-fn query_result_reports_source_port_mismatch() {
+fn query_result_is_agnostic_to_source_port() {
     let mut store = CookieStore::default();
     let request_url = test_utils::url("https://example.com:8443/foo/bar");
-    let mismatched_port_url = test_utils::url("https://example.com:9443/foo/bar");
+    let other_port_url = test_utils::url("https://example.com:9443/foo/bar");
 
     inserted!(store.insert_response_cookie_str_with_context(
         "sid=1; Path=/foo; Secure",
         &InsertContext::http(&request_url),
     ));
 
-    let result = store.get_cookie_query_result(&QueryContext::http(&mismatched_port_url));
-    assert!(result.included_cookies.is_empty());
-    assert_eq!(result.excluded_cookies.len(), 1);
-    assert_eq!(result.excluded_cookies[0].cookie.name(), "sid");
-    assert_eq!(
-        result.excluded_cookies[0].reason,
-        CookieExclusionReason::PortMismatch
-    );
+    // RFC 6265 matching is port-agnostic: a cookie set on one port of a host
+    // is visible on every other port of the same host.
+    let result = store.get_cookie_query_result(&QueryContext::http(&other_port_url));
+    assert!(result.excluded_cookies.is_empty());
+    assert_eq!(result.included_cookies.len(), 1);
+    assert_eq!(result.included_cookies[0].name(), "sid");
+}
+
+#[test]
+fn host_only_cookie_is_shared_across_ports_of_the_same_host() {
+    let mut store = CookieStore::default();
+    let set_url = test_utils::url("http://127.0.0.1:8771/");
+    let other_port_url = test_utils::url("http://127.0.0.1:8768/check");
+
+    inserted!(store
+        .insert_response_cookie_str_with_context("a=1; Path=/", &InsertContext::http(&set_url),));
+
+    let result = store.get_cookie_query_result(&QueryContext::http(&other_port_url));
+    assert!(result.excluded_cookies.is_empty());
+    assert_eq!(result.included_cookies.len(), 1);
+    assert_eq!(result.included_cookies[0].name(), "a");
+    assert_eq!(result.included_cookies[0].value(), "1");
 }
 
 #[test]
@@ -200,7 +214,6 @@ fn access_query_result_accumulates_multiple_exclusion_reasons() {
         vec![
             CookieExclusionReason::PathMismatch,
             CookieExclusionReason::SecureOnly,
-            CookieExclusionReason::PortMismatch,
             CookieExclusionReason::SchemeMismatch,
             CookieExclusionReason::SameSiteStrict,
         ]

--- a/moli-cookie-store/src/cookie_store/tests/query_same_site.rs
+++ b/moli-cookie-store/src/cookie_store/tests/query_same_site.rs
@@ -370,7 +370,6 @@ fn access_query_result_reports_secure_cookie_capability_for_insecure_context() {
         sid.access_result.status.exclusion_reasons,
         vec![
             CookieExclusionReason::SecureOnly,
-            CookieExclusionReason::PortMismatch,
             CookieExclusionReason::SchemeMismatch,
         ]
     );

--- a/moli-protocol/src/domains/network/tests/subresource.rs
+++ b/moli-protocol/src/domains/network/tests/subresource.rs
@@ -3081,7 +3081,7 @@ fetch('{start_url}', {{ credentials: 'include' }})
     server.abort();
 }
 #[tokio::test(flavor = "multi_thread")]
-async fn page_fetch_same_host_different_port_reports_port_mismatch_cookie_exclusion() {
+async fn page_fetch_same_host_different_port_sends_host_only_cookie() {
     async fn page(target_url: String) -> impl IntoResponse {
         (
             [(CONTENT_TYPE.as_str(), "text/html")],
@@ -3177,12 +3177,12 @@ fetch('{target_url}', {{ credentials: 'include' }})
         })
         .expect("fetch request should emit requestWillBeSent");
     assert_eq!(
-        fetch_request["params"]["cookieAccessReport"]["excludedCookies"][0]["cookie"]["name"],
+        fetch_request["params"]["cookieAccessReport"]["includedCookies"][0]["cookie"]["name"],
         "sid"
     );
     assert_eq!(
-        fetch_request["params"]["cookieAccessReport"]["excludedCookies"][0]["exclusionReasons"],
-        json!(["PortMismatch"])
+        fetch_request["params"]["request"]["headers"]["Cookie"],
+        "sid=1"
     );
 
     server.abort();


### PR DESCRIPTION
Cookie inclusion was gated on source_port_mismatch, which excluded any
cookie whose recorded source port differed from the request port. That
scoped host-only cookies per (host, port), deviating from RFC 6265
(cookies are port-agnostic) and from Chromium, breaking cross-port
flows like a :3000 frontend sharing a session cookie with a :3001 API.

Remove the port-based exclusion from the query policy. The source_port
metadata and PortMismatch diagnostic remain on cookies and the CDP wire
format, but no longer gate inclusion (matching Chromium, which reports
the port but never blocks on it).

Update tests that asserted the old per-port behavior and add regression
coverage: a host-only Path=/ cookie set on one port of 127.0.0.1 is
visible at another port via query, document.cookie, and the request
Cookie header.