### PR TITLE
feat(canvas): rasterize 2D path fills and strokes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2868,6 +2868,7 @@ dependencies = [
  "http",
  "httpdate",
  "indexmap",
+ "kurbo",
  "markup5ever",
  "moli-action-window",
  "moli-broadcast-channel",

--- a/moli-canvas/src/lib.rs
+++ b/moli-canvas/src/lib.rs
@@ -55,6 +55,32 @@ mod tests {
     }
 
     #[test]
+    fn hex_alpha_canonicalization_round_trips_every_byte() {
+        for alpha in 0..=255_u8 {
+            let raw = format!("#12ab34{alpha:02x}");
+            let canonical = canonicalize_fill_style(&raw).expect("valid eight-digit hex");
+            assert_eq!(
+                fill_style_rgba(&canonical),
+                [0x12, 0xab, 0x34, alpha],
+                "{raw}: {canonical}"
+            );
+        }
+        for alpha in 0..16_u8 {
+            let raw = format!("#0f0{alpha:x}");
+            let canonical = canonicalize_fill_style(&raw).expect("valid four-digit hex");
+            assert_eq!(fill_style_rgba(&canonical), [0, 255, 0, alpha * 17]);
+        }
+    }
+
+    #[test]
+    fn malformed_hex_colors_cannot_panic_or_install_a_style() {
+        for raw in ["#", "#12", "#12345", "#gggg", "#💚", "#éé", "#0000000x"] {
+            assert_eq!(canonicalize_fill_style(raw), None, "{raw}");
+            assert_eq!(fill_style_rgba(raw), [0, 0, 0, 255], "{raw}");
+        }
+    }
+
+    #[test]
     fn data_url_zero_and_png_dimensions_are_stable() {
         assert_eq!(encode_data_url(&[], 0, 0).as_deref(), Some("data:,"));
 

--- a/moli-canvas/src/rect.rs
+++ b/moli-canvas/src/rect.rs
@@ -15,8 +15,7 @@ pub fn canonicalize_fill_style(raw: &str) -> Option<String> {
         if alpha == u8::MAX {
             return Some(format!("rgb({red}, {green}, {blue})"));
         }
-        let alpha = (f64::from(alpha) / 255.0 * 100.0).round() / 100.0;
-        return Some(format!("rgba({red}, {green}, {blue}, {alpha:.2})"));
+        return Some(canonical_rgba(red, green, blue, alpha));
     }
     None
 }
@@ -300,34 +299,22 @@ pub fn paint_rect(
 }
 
 fn canonical_hex_color(value: &str) -> Option<String> {
-    let hex = value.strip_prefix('#')?;
-    if !hex.chars().all(|char| char.is_ascii_hexdigit()) {
-        return None;
+    let [red, green, blue, alpha] = hex_color_rgba(value)?;
+    if alpha == u8::MAX {
+        Some(format!("#{red:02x}{green:02x}{blue:02x}"))
+    } else {
+        Some(canonical_rgba(red, green, blue, alpha))
     }
-    match hex.len() {
-        3 => {
-            let chars = hex.chars().collect::<Vec<_>>();
-            Some(format!(
-                "#{0}{0}{1}{1}{2}{2}",
-                chars[0].to_ascii_lowercase(),
-                chars[1].to_ascii_lowercase(),
-                chars[2].to_ascii_lowercase()
-            ))
-        }
-        6 => Some(format!("#{hex}")),
-        8 => {
-            let rgba = u32::from_str_radix(hex, 16).ok()?;
-            let red = ((rgba >> 24) & 0xff) as u8;
-            let green = ((rgba >> 16) & 0xff) as u8;
-            let blue = ((rgba >> 8) & 0xff) as u8;
-            let alpha = (rgba & 0xff) as u8;
-            if alpha == u8::MAX {
-                Some(format!("#{red:02x}{green:02x}{blue:02x}"))
-            } else {
-                let alpha = (alpha as f64 / 255.0 * 100.0).round() / 100.0;
-                Some(format!("rgba({red}, {green}, {blue}, {alpha:.2})"))
-            }
-        }
-        _ => None,
+}
+
+fn canonical_rgba(red: u8, green: u8, blue: u8, alpha: u8) -> String {
+    let fraction = f64::from(alpha) / 255.0;
+    let rounded = (fraction * 100.0).round() / 100.0;
+    if (rounded * 255.0).round() as u8 == alpha {
+        format!("rgba({red}, {green}, {blue}, {rounded:.2})")
+    } else {
+        // Two decimal places cannot represent every 8-bit alpha. Retain enough
+        // precision that serializing a style does not change its pixels.
+        format!("rgba({red}, {green}, {blue}, {fraction:.3})")
     }
 }

--- a/moli-renderer-v8/Cargo.toml
+++ b/moli-renderer-v8/Cargo.toml
@@ -24,6 +24,7 @@ data-url = "0.3.2"
 dom = { package = "stylo_dom", version = "0.20" }
 encoding_rs = "0.8"
 euclid = "0.22"
+kurbo = "0.13.1"
 futures-util = "0.3.31"
 precomputed-hash = "0.1"
 percent-encoding = "2.3"

--- a/moli-renderer-v8/src/context_bootstrap/canvas.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas.rs
@@ -193,6 +193,7 @@ mod objects;
 mod offscreen;
 mod path;
 mod state;
+mod transform;
 mod webgl;
 
 pub(crate) use backing_store::{

--- a/moli-renderer-v8/src/context_bootstrap/canvas.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas.rs
@@ -192,6 +192,7 @@ mod image_bitmap;
 mod objects;
 mod offscreen;
 mod path;
+mod state;
 mod webgl;
 
 pub(crate) use backing_store::{

--- a/moli-renderer-v8/src/context_bootstrap/canvas/backing_store.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas/backing_store.rs
@@ -12,6 +12,7 @@ use moli_webapi_declare::WebApiObject;
 const CANVAS_BACKING_STORE_SLOT: &str = "__moliCanvasBackingStore";
 const CANVAS_OWNER_SLOT: &str = "__moliCanvasOwner";
 const CANVAS_HAS_CONTEXT_SLOT: &str = "__moliCanvasHasContext";
+const CANVAS_2D_CONTEXT_SLOT: &str = "__moliCanvas2DContext";
 
 #[derive(WebApiObject)]
 #[webapi(interface = "Object")]
@@ -27,6 +28,9 @@ pub(crate) fn attach_canvas_like_context_object<'s>(
 ) {
     let _ = CanvasContextOwnerDeclaration::new(canvas).initialize(scope, context);
     set_private_value(scope, context, CANVAS_OWNER_SLOT, canvas.into());
+    if get_private_value(scope, context, super::CANVAS_CONTEXT_FILL_STYLE_SLOT).is_some() {
+        set_private_value(scope, canvas, CANVAS_2D_CONTEXT_SLOT, context.into());
+    }
     set_private_value(
         scope,
         canvas,
@@ -48,6 +52,9 @@ pub(crate) fn reset_canvas_like_backing_store<'s>(
     scope: &mut v8::PinScope<'s, '_>,
     canvas: v8::Local<'s, v8::Object>,
 ) {
+    if let Some(context) = canvas_2d_context(scope, canvas) {
+        super::context2d::reset_canvas_context_state(scope, context);
+    }
     let Some((width, height)) = canvas_like_dimensions(scope, canvas) else {
         remove_html_canvas_pixels(scope, canvas);
         return;
@@ -62,6 +69,13 @@ pub(crate) fn reset_canvas_like_backing_store<'s>(
     };
     set_private_value(scope, canvas, CANVAS_BACKING_STORE_SLOT, bytes.into());
     replace_html_canvas_pixels(scope, canvas, width, height, vec![0; len]);
+}
+
+pub(super) fn canvas_2d_context<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    canvas: v8::Local<'s, v8::Object>,
+) -> Option<v8::Local<'s, v8::Object>> {
+    get_private_object(scope, canvas, CANVAS_2D_CONTEXT_SLOT)
 }
 
 pub(crate) fn reset_html_canvas_backing_store_for_dimension_assignment<'s>(

--- a/moli-renderer-v8/src/context_bootstrap/canvas/context2d.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas/context2d.rs
@@ -1059,13 +1059,13 @@ pub(crate) fn canvas_context_fill_callback<'s>(
     };
     let path_state = canvas_path_state(scope, args.this());
     let fragment = with_path_state(&path_state, |state| {
-        if state.is_empty() {
+        if state.is_empty() || state.inverse_transform().is_none() {
             return None;
         }
         Some(PaintFragment::Fill {
             shape: PaintShape::Path(state.paint_path()),
             brush: PaintBrush::Solid(context_fill_color(scope, args.this())),
-            transform: state.transform(),
+            transform: PaintTransform2D::IDENTITY,
         })
     });
     if let Some(fragment) = fragment {
@@ -1093,7 +1093,7 @@ pub(crate) fn canvas_context_stroke_callback<'s>(
         Some(PaintFragment::Stroke(context_stroke(
             scope,
             args.this(),
-            state.paint_path(),
+            state.stroke_path()?,
             state.transform(),
         )))
     });
@@ -1133,12 +1133,15 @@ pub(crate) fn canvas_context_stroke_rect_callback<'s>(
     };
     let path_state = canvas_path_state(scope, args.this());
     // strokeRect must not alter the current default path.
-    let (path, transform) = with_path_state(&path_state, |state| {
-        let mut rect_path = state.clone();
-        rect_path.begin_path();
+    let path = with_path_state(&path_state, |state| {
+        let mut rect_path = super::path::Canvas2dPathState::default();
         rect_path.rect(x, y, width, height);
-        (rect_path.paint_path(), state.transform())
+        state.inverse_transform()?;
+        Some((rect_path.paint_path(), state.transform()))
     });
+    let Some((path, transform)) = path else {
+        return;
+    };
     let stroke = context_stroke(scope, args.this(), path, transform);
     rasterize_canvas_fragment(scope, canvas, PaintFragment::Stroke(stroke));
     rv.set_undefined();

--- a/moli-renderer-v8/src/context_bootstrap/canvas/context2d.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas/context2d.rs
@@ -2,9 +2,7 @@ use super::backing_store::{
     canvas_like_pixels_copy, canvas_owner_from_context, with_canvas_like_pixels_mut,
 };
 use super::helpers::{canonical_canvas_fill_style, canvas_unrestricted_double_arg};
-use super::path::{
-    CANVAS_CONTEXT_PATH_STATE_ID_SLOT, allocate_canvas_path_state_id, with_canvas_path_state_mut,
-};
+use super::state::canvas_path_state;
 use super::*;
 use crate::context_bootstrap::image_data::{
     build_image_data_object, build_image_data_object_with_bytes, image_data_bytes_from_object,
@@ -27,6 +25,16 @@ use std::str::FromStr;
 
 const DEFAULT_IMAGE_SMOOTHING_QUALITY: &str = "low";
 const CANVAS_CONTEXT_LINE_DASH_SLOT: &str = "__moliCanvasContextLineDash";
+
+pub(super) fn reset_canvas_context_state<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    context: v8::Local<'s, v8::Object>,
+) {
+    super::helpers::init_canvas_like_context_object(scope, context);
+    let dash = v8::Array::new(scope, 0);
+    set_private_value(scope, context, CANVAS_CONTEXT_LINE_DASH_SLOT, dash.into());
+    super::state::reset_canvas_path_state(scope, context);
+}
 
 #[derive(WebApiObject)]
 #[webapi(interface = "Object")]
@@ -752,10 +760,8 @@ pub(crate) fn canvas_context_rect_callback<'s>(
     let Some(parsed) = webidl::parse_args::<CanvasContextRectPathArgs>(scope, &args) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| {
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| {
         state.rect(parsed.x, parsed.y, parsed.width, parsed.height);
     });
 }
@@ -768,10 +774,8 @@ pub(crate) fn canvas_context_begin_path_callback<'s>(
     if !require_canvas_context_receiver(scope, args.this(), "beginPath") {
         return;
     }
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| state.begin_path());
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| state.begin_path());
 }
 
 pub(crate) fn canvas_context_close_path_callback<'s>(
@@ -782,10 +786,8 @@ pub(crate) fn canvas_context_close_path_callback<'s>(
     if !require_canvas_context_receiver(scope, args.this(), "closePath") {
         return;
     }
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| state.close_path());
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| state.close_path());
 }
 
 pub(crate) fn canvas_context_move_to_callback<'s>(
@@ -799,10 +801,8 @@ pub(crate) fn canvas_context_move_to_callback<'s>(
     let Some(parsed) = webidl::parse_args::<CanvasContextMoveToArgs>(scope, &args) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| state.move_to(parsed.x, parsed.y));
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| state.move_to(parsed.x, parsed.y));
 }
 
 pub(crate) fn canvas_context_line_to_callback<'s>(
@@ -816,10 +816,8 @@ pub(crate) fn canvas_context_line_to_callback<'s>(
     let Some(parsed) = webidl::parse_args::<CanvasContextLineToArgs>(scope, &args) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| state.line_to(parsed.x, parsed.y));
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| state.line_to(parsed.x, parsed.y));
 }
 
 pub(crate) fn canvas_context_quadratic_curve_to_callback<'s>(
@@ -833,10 +831,8 @@ pub(crate) fn canvas_context_quadratic_curve_to_callback<'s>(
     let Some(parsed) = webidl::parse_args::<CanvasContextQuadraticCurveToArgs>(scope, &args) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| {
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| {
         state.quadratic_curve_to(parsed.cpx, parsed.cpy, parsed.x, parsed.y);
     });
 }
@@ -852,10 +848,8 @@ pub(crate) fn canvas_context_bezier_curve_to_callback<'s>(
     let Some(parsed) = webidl::parse_args::<CanvasContextBezierCurveToArgs>(scope, &args) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| {
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| {
         state.bezier_curve_to(
             parsed.cp1x,
             parsed.cp1y,
@@ -883,11 +877,8 @@ pub(crate) fn canvas_context_arc_callback<'s>(
         rv.set_undefined();
         return;
     }
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        rv.set_undefined();
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| {
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| {
         state.arc(
             parsed.x,
             parsed.y,
@@ -916,11 +907,8 @@ pub(crate) fn canvas_context_arc_to_callback<'s>(
         rv.set_undefined();
         return;
     }
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        rv.set_undefined();
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| {
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| {
         state.arc_to(parsed.x1, parsed.y1, parsed.x2, parsed.y2, parsed.radius);
     });
     rv.set_undefined();
@@ -942,11 +930,8 @@ pub(crate) fn canvas_context_ellipse_callback<'s>(
         rv.set_undefined();
         return;
     }
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        rv.set_undefined();
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| {
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| {
         state.ellipse(
             parsed.x,
             parsed.y,
@@ -976,10 +961,8 @@ pub(crate) fn canvas_context_translate_callback<'s>(
     let Some(y) = canvas_required_unrestricted_double_arg(scope, &args, 1, prefix) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| state.translate(x, y));
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| state.translate(x, y));
 }
 
 pub(crate) fn canvas_context_scale_callback<'s>(
@@ -997,10 +980,8 @@ pub(crate) fn canvas_context_scale_callback<'s>(
     let Some(y) = canvas_required_unrestricted_double_arg(scope, &args, 1, prefix) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| state.scale(x, y));
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| state.scale(x, y));
 }
 
 pub(crate) fn canvas_context_rotate_callback<'s>(
@@ -1015,10 +996,8 @@ pub(crate) fn canvas_context_rotate_callback<'s>(
     let Some(angle) = canvas_required_unrestricted_double_arg(scope, &args, 0, prefix) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| state.rotate(angle));
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| state.rotate(angle));
 }
 
 pub(crate) fn canvas_context_transform_callback<'s>(
@@ -1032,10 +1011,8 @@ pub(crate) fn canvas_context_transform_callback<'s>(
     let Some(parsed) = webidl::parse_args::<CanvasContextTransformArgs>(scope, &args) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| {
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| {
         state.concatenate_transform(parsed.a, parsed.b, parsed.c, parsed.d, parsed.e, parsed.f);
     });
 }
@@ -1051,10 +1028,8 @@ pub(crate) fn canvas_context_set_transform_callback<'s>(
     let Some(parsed) = webidl::parse_args::<CanvasContextTransformArgs>(scope, &args) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| {
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| {
         state.set_transform(parsed.a, parsed.b, parsed.c, parsed.d, parsed.e, parsed.f);
     });
 }
@@ -1067,10 +1042,8 @@ pub(crate) fn canvas_context_reset_transform_callback<'s>(
     if !require_canvas_context_receiver(scope, args.this(), "resetTransform") {
         return;
     }
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        return;
-    };
-    with_canvas_path_state_mut(id, |state| state.reset_transform());
+    let path_state = canvas_path_state(scope, args.this());
+    with_path_state(&path_state, |state| state.reset_transform());
 }
 
 pub(crate) fn canvas_context_fill_callback<'s>(
@@ -1084,11 +1057,8 @@ pub(crate) fn canvas_context_fill_callback<'s>(
     let Some(canvas) = canvas_owner_from_context(scope, args.this()) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        rv.set_undefined();
-        return;
-    };
-    let fragment = with_canvas_path_state_mut(id, |state| {
+    let path_state = canvas_path_state(scope, args.this());
+    let fragment = with_path_state(&path_state, |state| {
         if state.is_empty() {
             return None;
         }
@@ -1115,11 +1085,8 @@ pub(crate) fn canvas_context_stroke_callback<'s>(
     let Some(canvas) = canvas_owner_from_context(scope, args.this()) else {
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        rv.set_undefined();
-        return;
-    };
-    let fragment = with_canvas_path_state_mut(id, |state| {
+    let path_state = canvas_path_state(scope, args.this());
+    let fragment = with_path_state(&path_state, |state| {
         if state.is_empty() {
             return None;
         }
@@ -1164,12 +1131,9 @@ pub(crate) fn canvas_context_stroke_rect_callback<'s>(
         rv.set_undefined();
         return;
     };
-    let Some(id) = ensure_canvas_context_path_state_id(scope, args.this()) else {
-        rv.set_undefined();
-        return;
-    };
+    let path_state = canvas_path_state(scope, args.this());
     // strokeRect must not alter the current default path.
-    let (path, transform) = with_canvas_path_state_mut(id, |state| {
+    let (path, transform) = with_path_state(&path_state, |state| {
         let mut rect_path = state.clone();
         rect_path.begin_path();
         rect_path.rect(x, y, width, height);
@@ -1434,16 +1398,11 @@ fn canvas_context_enum_string_assign<'s>(
     }
 }
 
-fn ensure_canvas_context_path_state_id<'s>(
-    scope: &mut v8::PinScope<'s, '_>,
-    context: v8::Local<'s, v8::Object>,
-) -> Option<u64> {
-    if let Some(id) = context_number_slot(scope, context, CANVAS_CONTEXT_PATH_STATE_ID_SLOT) {
-        return Some(id as u64);
-    }
-    let id = allocate_canvas_path_state_id();
-    set_context_number_slot(scope, context, CANVAS_CONTEXT_PATH_STATE_ID_SLOT, id as f64);
-    Some(id)
+fn with_path_state<T>(
+    state: &std::cell::RefCell<super::path::Canvas2dPathState>,
+    update: impl FnOnce(&mut super::path::Canvas2dPathState) -> T,
+) -> T {
+    update(&mut state.borrow_mut())
 }
 
 fn context_fill_color<'s>(

--- a/moli-renderer-v8/src/context_bootstrap/canvas/context2d.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas/context2d.rs
@@ -272,23 +272,6 @@ struct CanvasContextEllipseArgs {
     counterclockwise: bool,
 }
 
-#[derive(webidl::WebIdlArgs)]
-#[webidl(prefix = "CanvasRenderingContext2D.transform")]
-struct CanvasContextTransformArgs {
-    #[webidl(required)]
-    a: f64,
-    #[webidl(required)]
-    b: f64,
-    #[webidl(required)]
-    c: f64,
-    #[webidl(required)]
-    d: f64,
-    #[webidl(required)]
-    e: f64,
-    #[webidl(required)]
-    f: f64,
-}
-
 fn require_canvas_context_receiver<'s>(
     scope: &mut v8::PinScope<'s, '_>,
     receiver: v8::Local<'s, v8::Object>,
@@ -872,6 +855,18 @@ pub(crate) fn canvas_context_arc_callback<'s>(
     let Some(parsed) = webidl::parse_args::<CanvasContextArcArgs>(scope, &args) else {
         return;
     };
+    if ![
+        parsed.x,
+        parsed.y,
+        parsed.radius,
+        parsed.start_angle,
+        parsed.end_angle,
+    ]
+    .into_iter()
+    .all(f64::is_finite)
+    {
+        return;
+    }
     if parsed.radius < 0.0 {
         webidl::throw_index_size_error(scope);
         rv.set_undefined();
@@ -902,6 +897,12 @@ pub(crate) fn canvas_context_arc_to_callback<'s>(
     let Some(parsed) = webidl::parse_args::<CanvasContextArcToArgs>(scope, &args) else {
         return;
     };
+    if ![parsed.x1, parsed.y1, parsed.x2, parsed.y2, parsed.radius]
+        .into_iter()
+        .all(f64::is_finite)
+    {
+        return;
+    }
     if parsed.radius < 0.0 {
         webidl::throw_index_size_error(scope);
         rv.set_undefined();
@@ -925,6 +926,20 @@ pub(crate) fn canvas_context_ellipse_callback<'s>(
     let Some(parsed) = webidl::parse_args::<CanvasContextEllipseArgs>(scope, &args) else {
         return;
     };
+    if ![
+        parsed.x,
+        parsed.y,
+        parsed.radius_x,
+        parsed.radius_y,
+        parsed.rotation,
+        parsed.start_angle,
+        parsed.end_angle,
+    ]
+    .into_iter()
+    .all(f64::is_finite)
+    {
+        return;
+    }
     if parsed.radius_x < 0.0 || parsed.radius_y < 0.0 {
         webidl::throw_index_size_error(scope);
         rv.set_undefined();
@@ -1008,12 +1023,14 @@ pub(crate) fn canvas_context_transform_callback<'s>(
     if !require_canvas_context_receiver(scope, args.this(), "transform") {
         return;
     }
-    let Some(parsed) = webidl::parse_args::<CanvasContextTransformArgs>(scope, &args) else {
+    let Some([a, b, c, d, e, f]) =
+        super::transform::transform_arguments(scope, &args, "CanvasRenderingContext2D.transform")
+    else {
         return;
     };
     let path_state = canvas_path_state(scope, args.this());
     with_path_state(&path_state, |state| {
-        state.concatenate_transform(parsed.a, parsed.b, parsed.c, parsed.d, parsed.e, parsed.f);
+        state.concatenate_transform(a, b, c, d, e, f);
     });
 }
 
@@ -1025,12 +1042,12 @@ pub(crate) fn canvas_context_set_transform_callback<'s>(
     if !require_canvas_context_receiver(scope, args.this(), "setTransform") {
         return;
     }
-    let Some(parsed) = webidl::parse_args::<CanvasContextTransformArgs>(scope, &args) else {
+    let Some([a, b, c, d, e, f]) = super::transform::set_transform_arguments(scope, &args) else {
         return;
     };
     let path_state = canvas_path_state(scope, args.this());
     with_path_state(&path_state, |state| {
-        state.set_transform(parsed.a, parsed.b, parsed.c, parsed.d, parsed.e, parsed.f);
+        state.set_transform(a, b, c, d, e, f);
     });
 }
 
@@ -1168,7 +1185,7 @@ pub(crate) fn canvas_context_line_width_setter_callback<'s>(
     if !require_canvas_context_receiver(scope, args.this(), "lineWidth setter") {
         return;
     }
-    canvas_context_nonnegative_number_assign(
+    canvas_context_positive_number_assign(
         scope,
         args.this(),
         args.get(0),
@@ -1198,7 +1215,7 @@ pub(crate) fn canvas_context_miter_limit_setter_callback<'s>(
     if !require_canvas_context_receiver(scope, args.this(), "miterLimit setter") {
         return;
     }
-    canvas_context_nonnegative_number_assign(
+    canvas_context_positive_number_assign(
         scope,
         args.this(),
         args.get(0),
@@ -1365,7 +1382,7 @@ pub(crate) fn canvas_context_stroke_style_setter_callback<'s>(
     rv.set_undefined();
 }
 
-fn canvas_context_nonnegative_number_assign<'s>(
+fn canvas_context_positive_number_assign<'s>(
     scope: &mut v8::PinScope<'s, '_>,
     holder: v8::Local<'s, v8::Object>,
     value: v8::Local<'s, v8::Value>,
@@ -1378,7 +1395,7 @@ fn canvas_context_nonnegative_number_assign<'s>(
     );
     if let Ok(value) = value {
         let value = f64::from(value);
-        if value.is_finite() && value >= 0.0 {
+        if value.is_finite() && value > 0.0 {
             set_context_number_slot(scope, holder, slot, value);
         }
     }

--- a/moli-renderer-v8/src/context_bootstrap/canvas/offscreen.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas/offscreen.rs
@@ -152,7 +152,9 @@ pub(crate) fn offscreen_canvas_get_context_callback<'s>(
         return;
     };
     let value = (match kind {
-        CanvasContextKind::TwoD => build_offscreen_2d_context_object(scope).map(Into::into),
+        CanvasContextKind::TwoD => super::backing_store::canvas_2d_context(scope, args.this())
+            .or_else(|| build_offscreen_2d_context_object(scope))
+            .map(Into::into),
         CanvasContextKind::WebGl => build_webgl_context_object(scope).map(Into::into),
         CanvasContextKind::WebGl2 => build_webgl2_context_object(scope).map(Into::into),
     })

--- a/moli-renderer-v8/src/context_bootstrap/canvas/path.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas/path.rs
@@ -87,8 +87,7 @@ impl Canvas2dPathState {
         self.just_closed = false;
     }
 
-    /// Returns `false` when the path has no subpath, matching the spec: line
-    /// and curve commands must do nothing when the path has no subpaths.
+    /// Reopens a closed subpath; callers establish the initial point for an empty path.
     fn ensure_open_subpath(&mut self) -> bool {
         if !self.has_subpath {
             return false;
@@ -106,6 +105,7 @@ impl Canvas2dPathState {
 
     pub(super) fn line_to(&mut self, x: f64, y: f64) {
         if !self.ensure_open_subpath() {
+            self.move_to(x, y);
             return;
         }
         self.elements.push(PaintPathElement::LineTo(point(x, y)));
@@ -114,7 +114,7 @@ impl Canvas2dPathState {
 
     pub(super) fn quadratic_curve_to(&mut self, cpx: f64, cpy: f64, x: f64, y: f64) {
         if !self.ensure_open_subpath() {
-            return;
+            self.move_to(cpx, cpy);
         }
         self.elements
             .push(PaintPathElement::QuadTo(point(cpx, cpy), point(x, y)));
@@ -131,7 +131,7 @@ impl Canvas2dPathState {
         y: f64,
     ) {
         if !self.ensure_open_subpath() {
-            return;
+            self.move_to(c1x, c1y);
         }
         self.elements.push(PaintPathElement::CubicTo(
             point(c1x, c1y),
@@ -158,8 +158,7 @@ impl Canvas2dPathState {
         self.close_path();
     }
 
-    /// Appends the path for `ctx.arc(...)`. Returns `false` when the arguments
-    /// are non-finite or the radius is negative (caller reports the error).
+    /// Canvas arcs use positive angles clockwise in the screen's y-down space.
     pub(super) fn arc(
         &mut self,
         x: f64,
@@ -169,33 +168,9 @@ impl Canvas2dPathState {
         end: f64,
         ccw: bool,
     ) -> bool {
-        if !x.is_finite()
-            || !y.is_finite()
-            || !radius.is_finite()
-            || !start.is_finite()
-            || !end.is_finite()
-        {
-            return false;
-        }
-        if radius < 0.0 {
-            return false;
-        }
-        if radius == 0.0 {
-            return true;
-        }
-        let (start, end) = normalized_arc_angles(start, end, ccw);
-        let start_point = (x + radius * start.cos(), y + radius * start.sin());
-        if !self.has_subpath {
-            self.move_to(start_point.0, start_point.1);
-        } else if self.current != start_point {
-            self.line_to(start_point.0, start_point.1);
-        }
-        self.push_arc_cubics((x, y), radius, start, end, ccw);
-        self.current = (x + radius * end.cos(), y + radius * end.sin());
-        true
+        self.ellipse(x, y, radius, radius, 0.0, start, end, ccw)
     }
 
-    /// Appends the path for `ctx.ellipse(...)`.
     pub(super) fn ellipse(
         &mut self,
         x: f64,
@@ -207,181 +182,74 @@ impl Canvas2dPathState {
         end: f64,
         ccw: bool,
     ) -> bool {
-        if !x.is_finite()
-            || !y.is_finite()
-            || !radius_x.is_finite()
-            || !radius_y.is_finite()
-            || !rotation.is_finite()
-            || !start.is_finite()
-            || !end.is_finite()
+        if ![x, y, radius_x, radius_y, rotation, start, end]
+            .into_iter()
+            .all(f64::is_finite)
+            || radius_x < 0.0
+            || radius_y < 0.0
         {
             return false;
         }
-        if radius_x < 0.0 || radius_y < 0.0 {
-            return false;
-        }
-        if radius_x == 0.0 || radius_y == 0.0 {
-            return true;
-        }
-        let (start, end) = normalized_arc_angles(start, end, ccw);
-        // Map unit-circle angles through the ellipse's scale + rotation.
-        let ellipse_transform = LayoutTransform2D::IDENTITY
-            .concatenate(LayoutTransform2D::rotation(rotation))
-            .concatenate(LayoutTransform2D::scale(radius_x, radius_y))
-            .concatenate(LayoutTransform2D::translation(x as f32, y as f32));
-        let start_point = transform_point(ellipse_transform, start.cos(), start.sin());
-        if !self.has_subpath {
-            self.move_to(start_point.0, start_point.1);
-        } else if self.current != start_point {
-            self.line_to(start_point.0, start_point.1);
-        }
-        self.push_ellipse_cubics(ellipse_transform, start, end, ccw);
-        let end_point = transform_point(ellipse_transform, end.cos(), end.sin());
-        self.current = end_point;
+        let (start, sweep) = arc_angles(start, end, ccw);
+        self.append_arc(kurbo::Arc::new(
+            (x, y),
+            (radius_x, radius_y),
+            start,
+            sweep,
+            rotation.rem_euclid(TWO_PI),
+        ));
         true
     }
 
-    /// Appends the path for `ctx.arcTo(...)`.
     pub(super) fn arc_to(&mut self, x1: f64, y1: f64, x2: f64, y2: f64, radius: f64) -> bool {
-        if !x1.is_finite()
-            || !y1.is_finite()
-            || !x2.is_finite()
-            || !y2.is_finite()
-            || !radius.is_finite()
-        {
-            return false;
-        }
-        if radius < 0.0 {
+        if ![x1, y1, x2, y2, radius].into_iter().all(f64::is_finite) || radius < 0.0 {
             return false;
         }
         if !self.has_subpath {
+            self.move_to(x1, y1);
             return true;
         }
-        let (x0, y0) = self.current;
-        let (p1, p2) = ((x1, y1), (x2, y2));
-        if (x0, y0) == p1 || p1 == p2 || radius == 0.0 {
+        let p0 = kurbo::Point::from(self.current);
+        let p1 = kurbo::Point::new(x1, y1);
+        let p2 = kurbo::Point::new(x2, y2);
+        let incoming = p0 - p1;
+        let outgoing = p2 - p1;
+        if incoming.hypot() == 0.0 || outgoing.hypot() == 0.0 || radius == 0.0 {
             self.line_to(x1, y1);
             return true;
         }
-        let (x01, y01) = (p1.0 - x0, p1.1 - y0);
-        let (x12, y12) = (p2.0 - p1.0, p2.1 - p1.1);
-        let d01 = x01.hypot(y01);
-        let d12 = x12.hypot(y12);
-        if d01 <= f64::EPSILON || d12 <= f64::EPSILON {
+        // Both rays originate at the corner. There is no radius clamp: the
+        // tangent points may lie beyond either of the supplied line segments.
+        let u = incoming / incoming.hypot();
+        let v = outgoing / outgoing.hypot();
+        let cross = u.cross(v);
+        if cross == 0.0 || !cross.is_finite() {
             self.line_to(x1, y1);
             return true;
         }
-        let cross = x01 * y12 - y01 * x12;
-        if cross.abs() <= f64::EPSILON {
-            self.line_to(x1, y1);
-            return true;
-        }
-        let (ux01, uy01) = (x01 / d01, y01 / d01);
-        let (ux12, uy12) = (x12 / d12, y12 / d12);
-        let cos_theta = (x01 * x12 + y01 * y12) / (d01 * d12);
-        let cos_theta = cos_theta.clamp(-1.0, 1.0);
-        let theta = cos_theta.acos();
-        let half = theta / 2.0;
-        let tan_half = half.tan();
-        if !tan_half.is_finite() || tan_half.abs() <= f64::EPSILON {
-            self.line_to(x1, y1);
-            return true;
-        }
-        let max_radius = d01.min(d12) * tan_half;
-        let radius = radius.min(max_radius);
-        let tangent = radius / tan_half;
-        let (ta_x, ta_y) = (p1.0 + ux01 * tangent, p1.1 + uy01 * tangent);
-        let (tb_x, tb_y) = (p1.0 + ux12 * tangent, p1.1 + uy12 * tangent);
-        let (bx, by) = normalize((ux01 + ux12, uy01 + uy12));
-        let sin_half = half.sin();
-        if !sin_half.is_finite() || sin_half.abs() <= f64::EPSILON {
-            self.line_to(x1, y1);
-            return true;
-        }
-        let center = (
-            p1.0 + bx * (radius / sin_half),
-            p1.1 + by * (radius / sin_half),
-        );
-        let start_angle = (ta_y - center.1).atan2(ta_x - center.0);
-        let end_angle = (tb_y - center.1).atan2(tb_x - center.0);
-        let ccw = cross < 0.0;
-        self.push_arc_cubics(center, radius, start_angle, end_angle, ccw);
-        self.current = (tb_x, tb_y);
+        let tangent_distance = radius * ((1.0 + u.dot(v).clamp(-1.0, 1.0)) / cross.abs());
+        let tangent = p1 + u * tangent_distance;
+        let center = tangent + kurbo::Vec2::new(-u.y, u.x) * (radius * cross.signum());
+        let end = p1 + v * tangent_distance;
+        let start_angle = (tangent - center).atan2();
+        let end_angle = (end - center).atan2();
+        let (start, sweep) = arc_angles(start_angle, end_angle, cross > 0.0);
+        self.append_arc(kurbo::Arc::new(center, (radius, radius), start, sweep, 0.0));
         true
     }
 
-    /// Adds a straight connector to the current point when `connect` and the
-    /// current point differs from `target`, then appends cubic approximations
-    /// of the arc from `start` to `end` around `center` with radius `radius`.
-    fn push_arc_cubics(
-        &mut self,
-        center: (f64, f64),
-        radius: f64,
-        start: f64,
-        end: f64,
-        ccw: bool,
-    ) {
-        let sweep = signed_arc_sweep(start, end, ccw);
-        if sweep.abs() <= f64::EPSILON {
-            return;
-        }
-        let segments = (sweep.abs() / (std::f64::consts::FRAC_PI_2)).ceil() as usize;
-        let segments = segments.max(1);
-        let delta = sweep / segments as f64;
-        let mut angle = start;
-        for _ in 0..segments {
-            let next = angle + delta;
-            let (cos_a, sin_a) = angle.sin_cos();
-            let (cos_b, sin_b) = next.sin_cos();
-            let alpha = (4.0 / 3.0) * (1.0 - (delta / 2.0).cos()) / (delta / 2.0).sin();
-            let (p0x, p0y) = (center.0 + radius * cos_a, center.1 + radius * sin_a);
-            let (c1x, c1y) = (p0x - alpha * radius * sin_a, p0y + alpha * radius * cos_a);
-            let (p3x, p3y) = (center.0 + radius * cos_b, center.1 + radius * sin_b);
-            let (c2x, c2y) = (p3x + alpha * radius * sin_b, p3y - alpha * radius * cos_b);
-            self.elements.push(PaintPathElement::CubicTo(
-                point(c1x, c1y),
-                point(c2x, c2y),
-                point(p3x, p3y),
-            ));
-            self.current = (p3x, p3y);
-            angle = next;
-        }
-    }
+    fn append_arc(&mut self, arc: kurbo::Arc) {
+        use kurbo::{PathEl, Shape};
 
-    fn push_ellipse_cubics(
-        &mut self,
-        transform: LayoutTransform2D,
-        start: f64,
-        end: f64,
-        ccw: bool,
-    ) {
-        let sweep = signed_arc_sweep(start, end, ccw);
-        if sweep.abs() <= f64::EPSILON {
-            return;
-        }
-        let segments = (sweep.abs() / (std::f64::consts::FRAC_PI_2)).ceil() as usize;
-        let segments = segments.max(1);
-        let delta = sweep / segments as f64;
-        let mut angle = start;
-        for _ in 0..segments {
-            let next = angle + delta;
-            let (cos_a, sin_a) = angle.sin_cos();
-            let (cos_b, sin_b) = next.sin_cos();
-            let alpha = (4.0 / 3.0) * (1.0 - (delta / 2.0).cos()) / (delta / 2.0).sin();
-            let (p0x, p0y) = transform_point(transform, cos_a, sin_a);
-            let (p3x, p3y) = transform_point(transform, cos_b, sin_b);
-            // Tangents on the unit circle, then mapped through the transform.
-            let tangent_a = radius_tangent(transform, -sin_a, cos_a);
-            let tangent_b = radius_tangent(transform, -sin_b, cos_b);
-            let (c1x, c1y) = (p0x + alpha * tangent_a.0, p0y + alpha * tangent_a.1);
-            let (c2x, c2y) = (p3x - alpha * tangent_b.0, p3y - alpha * tangent_b.1);
-            self.elements.push(PaintPathElement::CubicTo(
-                point(c1x, c1y),
-                point(c2x, c2y),
-                point(p3x, p3y),
-            ));
-            self.current = (p3x, p3y);
-            angle = next;
+        // A relative floor also bounds subdivision for enormous but finite
+        // radii. It prevents resource usage growing without bound with radius.
+        let tolerance = 0.01_f64.max(arc.radii.x.max(arc.radii.y) / 4096.0);
+        for element in arc.path_elements(tolerance) {
+            match element {
+                PathEl::MoveTo(p) => self.line_to(p.x, p.y),
+                PathEl::CurveTo(a, b, p) => self.bezier_curve_to(a.x, a.y, b.x, b.y, p.x, p.y),
+                _ => unreachable!("kurbo arcs contain only a start point and cubic segments"),
+            }
         }
     }
 
@@ -478,51 +346,102 @@ fn expand(min_x: &mut f64, min_y: &mut f64, max_x: &mut f64, max_y: &mut f64, po
     *max_y = (*max_y).max(y);
 }
 
-fn normalize(vector: (f64, f64)) -> (f64, f64) {
-    let length = vector.0.hypot(vector.1);
-    if length <= f64::EPSILON {
-        (0.0, 0.0)
-    } else {
-        (vector.0 / length, vector.1 / length)
-    }
-}
-
-fn normalized_arc_angles(start: f64, end: f64, ccw: bool) -> (f64, f64) {
-    let mut end = end;
-    if ccw {
-        while end > start {
-            end -= TWO_PI;
-        }
-    } else {
-        while end < start {
-            end += TWO_PI;
-        }
-    }
-    (start, end)
-}
-
-/// Signed sweep angle (positive counterclockwise, negative clockwise) in
-/// `(-TAU, TAU]`. An exact full-circle difference is preserved as ±TAU.
-fn signed_arc_sweep(start: f64, end: f64, ccw: bool) -> f64 {
+/// Normalize in constant time, including opposite-sign finite angles whose
+/// subtraction overflows. Never repeatedly add/subtract TAU: at large f64
+/// magnitudes that operation does not advance at all.
+fn arc_angles(start: f64, end: f64, ccw: bool) -> (f64, f64) {
     let difference = end - start;
-    if difference.abs() >= TWO_PI {
-        return if ccw { TWO_PI } else { -TWO_PI };
-    }
-    if ccw {
-        difference.rem_euclid(TWO_PI)
+    let normalized_start = start.rem_euclid(TWO_PI);
+    let sweep = if !ccw && difference >= TWO_PI {
+        TWO_PI
+    } else if ccw && difference <= -TWO_PI {
+        -TWO_PI
+    } else if difference == 0.0 {
+        0.0
     } else {
-        -((start - end).rem_euclid(TWO_PI))
+        let remainder = if difference.is_finite() {
+            difference.rem_euclid(TWO_PI)
+        } else {
+            (end.rem_euclid(TWO_PI) - normalized_start).rem_euclid(TWO_PI)
+        };
+        if ccw {
+            // Like Blink's AdjustEndAngle, preserve a whole turn for opposite-
+            // direction endpoints separated by an exact multiple of TAU.
+            if remainder == 0.0 && difference < 0.0 {
+                0.0
+            } else {
+                remainder - TWO_PI
+            }
+        } else if remainder == 0.0 && difference < 0.0 {
+            TWO_PI
+        } else {
+            remainder
+        }
+    };
+    (normalized_start, sweep)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::FRAC_PI_2;
+
+    #[test]
+    fn arc_angles_preserve_direction_full_turns_and_equal_endpoints() {
+        for (start, end, ccw, expected) in [
+            (0.0, FRAC_PI_2, false, FRAC_PI_2),
+            (0.0, FRAC_PI_2, true, -3.0 * FRAC_PI_2),
+            (0.0, -FRAC_PI_2, true, -FRAC_PI_2),
+            (0.0, -FRAC_PI_2, false, 3.0 * FRAC_PI_2),
+            (0.0, TWO_PI, false, TWO_PI),
+            (0.0, -TWO_PI, true, -TWO_PI),
+            (0.0, TWO_PI, true, -TWO_PI),
+            (0.0, -TWO_PI, false, TWO_PI),
+            (2.0, 2.0, true, 0.0),
+            (2.0, 2.0, false, 0.0),
+        ] {
+            assert!((arc_angles(start, end, ccw).1 - expected).abs() < 1e-12);
+        }
     }
-}
 
-fn transform_point(transform: LayoutTransform2D, x: f64, y: f64) -> (f64, f64) {
-    let mapped = transform.map_point(LayoutPoint::new(x as f32, y as f32));
-    (f64::from(mapped.x), f64::from(mapped.y))
-}
+    #[test]
+    fn finite_extreme_angles_produce_bounded_path_work() {
+        for start in [0.0, 1e20, -1e20, f64::MAX, -f64::MAX] {
+            for end in [0.0, 1e20, -1e20, f64::MAX, -f64::MAX] {
+                for ccw in [false, true] {
+                    let (angle, sweep) = arc_angles(start, end, ccw);
+                    assert!(angle.is_finite() && (0.0..TWO_PI).contains(&angle));
+                    assert!(sweep.is_finite() && sweep.abs() <= TWO_PI);
+                    assert!(if ccw { sweep <= 0.0 } else { sweep >= 0.0 });
+                    let mut state = Canvas2dPathState::default();
+                    assert!(state.arc(10.0, 10.0, 5.0, start, end, ccw));
+                    assert!(state.elements.len() <= 7);
+                }
+            }
+        }
+    }
 
-/// Maps a unit-circle tangent through the ellipse's linear part only
-/// (scale + rotation, excluding translation).
-fn radius_tangent(transform: LayoutTransform2D, x: f64, y: f64) -> (f64, f64) {
-    let [a, b, c, d, _, _] = transform.coefficients;
-    (a * x + c * y, b * x + d * y)
+    #[test]
+    fn arc_to_has_the_correct_tangent_and_endpoint() {
+        let mut state = Canvas2dPathState::default();
+        state.move_to(0.0, 0.0);
+        assert!(state.arc_to(10.0, 0.0, 10.0, 10.0, 5.0));
+        let PaintPathElement::LineTo(tangent) = state.elements[1] else {
+            panic!("arcTo must connect to its first tangent");
+        };
+        assert!((tangent.x - 5.0).abs() < 1e-5 && tangent.y.abs() < 1e-5);
+        assert!((state.current.0 - 10.0).abs() < 1e-5);
+        assert!((state.current.1 - 5.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn rejected_arc_geometry_does_not_mutate_the_path() {
+        let mut state = Canvas2dPathState::default();
+        for invalid in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -1.0] {
+            assert!(!state.arc(0.0, 0.0, invalid, 0.0, 1.0, false));
+            assert!(!state.ellipse(0.0, 0.0, 5.0, invalid, 0.0, 0.0, 1.0, false));
+            assert!(!state.arc_to(0.0, 0.0, 1.0, 1.0, invalid));
+            assert!(state.is_empty());
+        }
+    }
 }

--- a/moli-renderer-v8/src/context_bootstrap/canvas/path.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas/path.rs
@@ -8,6 +8,8 @@ use moli_layout::{
 /// subpath, `Close` ends it, and a new `MoveTo` begins the next one.
 #[derive(Clone, Debug)]
 pub(crate) struct Canvas2dPathState {
+    // Default-path geometry is already in canvas coordinates. The current
+    // transform only affects newly recorded commands, never earlier elements.
     elements: Vec<PaintPathElement>,
     current: (f64, f64),
     current_subpath_start: (f64, f64),
@@ -41,6 +43,10 @@ impl Canvas2dPathState {
     }
 
     pub(super) fn move_to(&mut self, x: f64, y: f64) {
+        if ![x, y].into_iter().all(f64::is_finite) {
+            return;
+        }
+        let (x, y) = self.map_point(x, y);
         self.elements.push(PaintPathElement::MoveTo(point(x, y)));
         self.current = (x, y);
         self.current_subpath_start = (x, y);
@@ -65,18 +71,27 @@ impl Canvas2dPathState {
     }
 
     pub(super) fn line_to(&mut self, x: f64, y: f64) {
+        if ![x, y].into_iter().all(f64::is_finite) {
+            return;
+        }
         if !self.ensure_open_subpath() {
             self.move_to(x, y);
             return;
         }
+        let (x, y) = self.map_point(x, y);
         self.elements.push(PaintPathElement::LineTo(point(x, y)));
         self.current = (x, y);
     }
 
     pub(super) fn quadratic_curve_to(&mut self, cpx: f64, cpy: f64, x: f64, y: f64) {
+        if ![cpx, cpy, x, y].into_iter().all(f64::is_finite) {
+            return;
+        }
         if !self.ensure_open_subpath() {
             self.move_to(cpx, cpy);
         }
+        let (cpx, cpy) = self.map_point(cpx, cpy);
+        let (x, y) = self.map_point(x, y);
         self.elements
             .push(PaintPathElement::QuadTo(point(cpx, cpy), point(x, y)));
         self.current = (x, y);
@@ -91,9 +106,15 @@ impl Canvas2dPathState {
         x: f64,
         y: f64,
     ) {
+        if ![c1x, c1y, c2x, c2y, x, y].into_iter().all(f64::is_finite) {
+            return;
+        }
         if !self.ensure_open_subpath() {
             self.move_to(c1x, c1y);
         }
+        let (c1x, c1y) = self.map_point(c1x, c1y);
+        let (c2x, c2y) = self.map_point(c2x, c2y);
+        let (x, y) = self.map_point(x, y);
         self.elements.push(PaintPathElement::CubicTo(
             point(c1x, c1y),
             point(c2x, c2y),
@@ -112,6 +133,11 @@ impl Canvas2dPathState {
     }
 
     pub(super) fn rect(&mut self, x: f64, y: f64, width: f64, height: f64) {
+        if ![x, y, width, height].into_iter().all(f64::is_finite)
+            || self.inverse_transform().is_none()
+        {
+            return;
+        }
         self.move_to(x, y);
         self.line_to(x + width, y);
         self.line_to(x + width, y + height);
@@ -148,6 +174,7 @@ impl Canvas2dPathState {
             .all(f64::is_finite)
             || radius_x < 0.0
             || radius_y < 0.0
+            || self.inverse_transform().is_none()
         {
             return false;
         }
@@ -170,7 +197,13 @@ impl Canvas2dPathState {
             self.move_to(x1, y1);
             return true;
         }
-        let p0 = kurbo::Point::from(self.current);
+        let Some(inverse) = self.inverse_transform() else {
+            self.line_to(x1, y1);
+            return true;
+        };
+        // arcTo constructs a circular arc in the current user coordinate
+        // system. The previous point was recorded under a possibly older CTM.
+        let p0 = inverse * kurbo::Point::from(self.current);
         let p1 = kurbo::Point::new(x1, y1);
         let p2 = kurbo::Point::new(x2, y2);
         let incoming = p0 - p1;
@@ -215,7 +248,9 @@ impl Canvas2dPathState {
     }
 
     pub(super) fn set_transform(&mut self, a: f64, b: f64, c: f64, d: f64, e: f64, f: f64) {
-        self.transform = LayoutTransform2D::new([a, b, c, d, e, f]);
+        if [a, b, c, d, e, f].into_iter().all(f64::is_finite) {
+            self.transform = LayoutTransform2D::new([a, b, c, d, e, f]);
+        }
     }
 
     pub(super) fn reset_transform(&mut self) {
@@ -223,75 +258,115 @@ impl Canvas2dPathState {
     }
 
     pub(super) fn translate(&mut self, x: f64, y: f64) {
-        self.transform = self
-            .transform
-            .concatenate(LayoutTransform2D::translation(x as f32, y as f32));
+        self.concatenate_transform(1.0, 0.0, 0.0, 1.0, x, y);
     }
 
     pub(super) fn scale(&mut self, x: f64, y: f64) {
-        self.transform = self.transform.concatenate(LayoutTransform2D::scale(x, y));
+        self.concatenate_transform(x, 0.0, 0.0, y, 0.0, 0.0);
     }
 
     pub(super) fn rotate(&mut self, radians: f64) {
-        self.transform = self
-            .transform
-            .concatenate(LayoutTransform2D::rotation(radians));
+        let (sin, cos) = radians.sin_cos();
+        self.concatenate_transform(cos, sin, -sin, cos, 0.0, 0.0);
     }
 
     pub(super) fn concatenate_transform(&mut self, a: f64, b: f64, c: f64, d: f64, e: f64, f: f64) {
-        self.transform = self
-            .transform
-            .concatenate(LayoutTransform2D::new([a, b, c, d, e, f]));
+        if [a, b, c, d, e, f].into_iter().all(f64::is_finite) {
+            self.transform = self
+                .transform
+                .concatenate(LayoutTransform2D::new([a, b, c, d, e, f]));
+        }
     }
 
     pub(super) fn transform(&self) -> LayoutTransform2D {
         self.transform
     }
 
+    fn map_point(&self, x: f64, y: f64) -> (f64, f64) {
+        let p = kurbo::Affine::new(self.transform.coefficients) * kurbo::Point::new(x, y);
+        (p.x, p.y)
+    }
+
+    pub(super) fn inverse_transform(&self) -> Option<kurbo::Affine> {
+        let transform = kurbo::Affine::new(self.transform.coefficients);
+        let determinant = transform.determinant();
+        // A small nonzero scale is still invertible; do not use EPSILON as
+        // a singularity threshold (e.g. scale(1e-9,1e-9) is valid).
+        (determinant != 0.0 && determinant.is_finite()).then(|| transform.inverse())
+    }
+
+    /// Stroke metrics are in the *current* user space. Bring the frozen path
+    /// back to that space and let the painter transform the resulting stroke,
+    /// so anisotropic line widths, joins and dashes change without moving it.
+    pub(super) fn stroke_path(&self) -> Option<PaintPath> {
+        let inverse = self.inverse_transform()?;
+        let map = |p: LayoutPoint| {
+            let p = inverse * kurbo::Point::new(f64::from(p.x), f64::from(p.y));
+            point(p.x, p.y)
+        };
+        let elements = self
+            .elements
+            .iter()
+            .map(|element| match *element {
+                PaintPathElement::MoveTo(p) => PaintPathElement::MoveTo(map(p)),
+                PaintPathElement::LineTo(p) => PaintPathElement::LineTo(map(p)),
+                PaintPathElement::QuadTo(a, p) => PaintPathElement::QuadTo(map(a), map(p)),
+                PaintPathElement::CubicTo(a, b, p) => {
+                    PaintPathElement::CubicTo(map(a), map(b), map(p))
+                }
+                PaintPathElement::Close => PaintPathElement::Close,
+            })
+            .collect::<Vec<_>>();
+        Some(PaintPath {
+            bounds: path_bounds(&elements),
+            elements,
+        })
+    }
+
     /// Builds an owned `PaintPath` with conservative local bounds.
     pub(super) fn paint_path(&self) -> PaintPath {
         PaintPath {
             elements: self.elements.clone(),
-            bounds: self.bounds(),
+            bounds: path_bounds(&self.elements),
         }
     }
 
     pub(super) fn is_empty(&self) -> bool {
         self.elements.is_empty()
     }
+}
 
-    fn bounds(&self) -> PaintRect {
-        let mut min_x = f64::INFINITY;
-        let mut min_y = f64::INFINITY;
-        let mut max_x = f64::NEG_INFINITY;
-        let mut max_y = f64::NEG_INFINITY;
-        for element in &self.elements {
-            match *element {
-                PaintPathElement::MoveTo(point) | PaintPathElement::LineTo(point) => {
-                    expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, point);
-                }
-                PaintPathElement::QuadTo(first, second) => {
-                    expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, first);
-                    expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, second);
-                }
-                PaintPathElement::CubicTo(first, second, third) => {
-                    expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, first);
-                    expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, second);
-                    expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, third);
-                }
-                PaintPathElement::Close => {}
+fn path_bounds(elements: &[PaintPathElement]) -> PaintRect {
+    let mut min_x = f64::INFINITY;
+    let mut min_y = f64::INFINITY;
+    let mut max_x = f64::NEG_INFINITY;
+    let mut max_y = f64::NEG_INFINITY;
+    for element in elements {
+        match *element {
+            PaintPathElement::MoveTo(point) | PaintPathElement::LineTo(point) => {
+                expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, point);
             }
+            PaintPathElement::QuadTo(first, second) => {
+                expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, first);
+                expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, second);
+            }
+            PaintPathElement::CubicTo(first, second, third) => {
+                expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, first);
+                expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, second);
+                expand(&mut min_x, &mut min_y, &mut max_x, &mut max_y, third);
+            }
+            PaintPathElement::Close => {}
         }
-        if !min_x.is_finite() {
-            return LayoutRect::ZERO;
-        }
-        LayoutRect::new(
-            min_x as f32,
-            min_y as f32,
-            (max_x - min_x) as f32,
-            (max_y - min_y) as f32,
-        )
     }
+    if !min_x.is_finite() {
+        return LayoutRect::ZERO;
+    }
+    LayoutRect::new(
+        min_x as f32,
+        min_y as f32,
+        (max_x - min_x) as f32,
+        (max_y - min_y) as f32,
+    )
 }
 
 fn point(x: f64, y: f64) -> LayoutPoint {

--- a/moli-renderer-v8/src/context_bootstrap/canvas/path.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas/path.rs
@@ -1,25 +1,8 @@
-//! Canvas 2D current-path geometry.
-//!
-//! The CanvasRenderingContext2D path methods are thin V8 callbacks that
-//! translate into this module's geometry. The accumulated path is kept in a
-//! per-context side table keyed by a private-slot id (V8 private slots can
-//! only hold `Value`, so a numeric id + global map is used instead of storing
-//! a `Vec` directly on the object).
-//!
-//! Path elements map 1:1 onto [`moli_layout::PaintPathElement`] so the
-//! existing `moli_paint::raster_snapshot` pipeline (vello CPU) can fill and
-//! stroke them.
-
-use std::collections::HashMap;
-use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU64, Ordering};
+//! Canvas 2D current-path geometry, owned by the context's native state.
 
 use moli_layout::{
     LayoutPoint, LayoutRect, LayoutTransform2D, PaintPath, PaintPathElement, PaintRect,
 };
-use parking_lot::Mutex;
-
-pub(crate) const CANVAS_CONTEXT_PATH_STATE_ID_SLOT: &str = "__moliCanvasContextPathStateId";
 
 /// A Bezier path in the same flat form as a kurbo path: one `MoveTo` starts a
 /// subpath, `Close` ends it, and a new `MoveTo` begins the next one.
@@ -44,28 +27,6 @@ impl Default for Canvas2dPathState {
             transform: LayoutTransform2D::IDENTITY,
         }
     }
-}
-
-static NEXT_CANVAS_PATH_STATE_ID: AtomicU64 = AtomicU64::new(1);
-static CANVAS_PATH_STATES: OnceLock<Mutex<HashMap<u64, Canvas2dPathState>>> = OnceLock::new();
-
-fn canvas_path_states() -> &'static Mutex<HashMap<u64, Canvas2dPathState>> {
-    CANVAS_PATH_STATES.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-pub(crate) fn allocate_canvas_path_state_id() -> u64 {
-    NEXT_CANVAS_PATH_STATE_ID.fetch_add(1, Ordering::Relaxed)
-}
-
-/// Runs `update` against the current-path state for `id`, inserting a fresh
-/// state when the context has never recorded one.
-pub(crate) fn with_canvas_path_state_mut<T>(
-    id: u64,
-    update: impl FnOnce(&mut Canvas2dPathState) -> T,
-) -> T {
-    let mut states = canvas_path_states().lock();
-    let state = states.entry(id).or_default();
-    update(state)
 }
 
 const TWO_PI: f64 = std::f64::consts::TAU;

--- a/moli-renderer-v8/src/context_bootstrap/canvas/state.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas/state.rs
@@ -1,0 +1,131 @@
+//! Native path state belongs to the V8 context object, never to the process.
+//!
+//! The isolate owns the table. Weak context handles remove entries on GC;
+//! dropping the isolate also drops every remaining entry without needing GC.
+
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
+
+use super::path::Canvas2dPathState;
+use crate::util::{get_private_value, set_private_value};
+
+const PATH_STATE_SLOT: &str = "__moliCanvasPathState";
+type StateStore = Rc<RefCell<CanvasStates>>;
+
+#[derive(Default)]
+struct CanvasStates {
+    next_id: u64,
+    entries: HashMap<u64, CanvasStateEntry>,
+}
+
+struct CanvasStateEntry {
+    _context: v8::Weak<v8::Object>,
+    state: Rc<RefCell<Canvas2dPathState>>,
+}
+
+pub(super) fn canvas_path_state<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    context: v8::Local<'s, v8::Object>,
+) -> Rc<RefCell<Canvas2dPathState>> {
+    let store = if let Some(store) = scope.get_slot::<StateStore>() {
+        store.clone()
+    } else {
+        let store = StateStore::default();
+        scope.set_slot(store.clone());
+        store
+    };
+    if let Some(id) = get_private_value(scope, context, PATH_STATE_SLOT)
+        .and_then(|value| v8::Local::<v8::BigInt>::try_from(value).ok())
+        .map(|value| value.u64_value().0)
+    {
+        return store
+            .borrow()
+            .entries
+            .get(&id)
+            .expect("a live context must retain its native path state")
+            .state
+            .clone();
+    }
+    let id = {
+        let mut store = store.borrow_mut();
+        store.next_id = store
+            .next_id
+            .checked_add(1)
+            .expect("canvas state identity exhausted");
+        store.next_id
+    };
+    let weak_store = Rc::downgrade(&store);
+    let owner = v8::Weak::with_finalizer(
+        scope,
+        context,
+        Box::new(move |_| {
+            if let Some(store) = weak_store.upgrade() {
+                store.borrow_mut().entries.remove(&id);
+            }
+        }),
+    );
+    let state = Rc::new(RefCell::new(Canvas2dPathState::default()));
+    store.borrow_mut().entries.insert(
+        id,
+        CanvasStateEntry {
+            _context: owner,
+            state: state.clone(),
+        },
+    );
+    let id = v8::BigInt::new_from_u64(scope, id);
+    set_private_value(scope, context, PATH_STATE_SLOT, id.into());
+    state
+}
+
+pub(super) fn reset_canvas_path_state<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    context: v8::Local<'s, v8::Object>,
+) {
+    if get_private_value(scope, context, PATH_STATE_SLOT).is_some() {
+        *canvas_path_state(scope, context).borrow_mut() = Canvas2dPathState::default();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_state_is_reclaimed_with_context_gc_and_isolate_destruction() {
+        moli_v8_test_util::ensure_v8();
+        let state = {
+            let mut isolate = v8::Isolate::new(Default::default());
+            let state = {
+                let scope = std::pin::pin!(v8::HandleScope::new(&mut isolate));
+                let scope = &mut scope.init();
+                let context = v8::Context::new(scope, Default::default());
+                let scope = &mut v8::ContextScope::new(scope, context);
+                let object = v8::Object::new(scope);
+                let state = canvas_path_state(scope, object);
+                state.borrow_mut().rect(0.0, 0.0, 10.0, 10.0);
+                assert!(Rc::ptr_eq(&state, &canvas_path_state(scope, object)));
+                Rc::downgrade(&state)
+            };
+            isolate.low_memory_notification();
+            assert!(state.upgrade().is_none(), "GC must drop native path data");
+            assert!(
+                isolate
+                    .get_slot::<StateStore>()
+                    .unwrap()
+                    .borrow()
+                    .entries
+                    .is_empty()
+            );
+
+            let scope = std::pin::pin!(v8::HandleScope::new(&mut isolate));
+            let scope = &mut scope.init();
+            let context = v8::Context::new(scope, Default::default());
+            let scope = &mut v8::ContextScope::new(scope, context);
+            let object = v8::Object::new(scope);
+            Rc::downgrade(&canvas_path_state(scope, object))
+        };
+        assert!(
+            state.upgrade().is_none(),
+            "isolate teardown must not depend on GC"
+        );
+    }
+}

--- a/moli-renderer-v8/src/context_bootstrap/canvas/transform.rs
+++ b/moli-renderer-v8/src/context_bootstrap/canvas/transform.rs
@@ -1,0 +1,88 @@
+//! WebIDL conversion and DOMMatrix2DInit alias validation for Canvas transforms.
+
+use crate::{util::throw_type_error, webidl};
+
+#[derive(Default, webidl::WebIdlDictionary)]
+#[webidl(prefix = "DOMMatrix2DInit")]
+struct TransformInit {
+    a: Option<f64>,
+    b: Option<f64>,
+    c: Option<f64>,
+    d: Option<f64>,
+    e: Option<f64>,
+    f: Option<f64>,
+    m11: Option<f64>,
+    m12: Option<f64>,
+    m21: Option<f64>,
+    m22: Option<f64>,
+    m41: Option<f64>,
+    m42: Option<f64>,
+}
+
+pub(super) fn transform_arguments<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    args: &v8::FunctionCallbackArguments<'s>,
+    prefix: &'static str,
+) -> Option<[f64; 6]> {
+    if args.length() < 6 {
+        throw_type_error(scope, &format!("{prefix} requires six arguments"));
+        return None;
+    }
+    let mut values = [0.0; 6];
+    for (index, value) in values.iter_mut().enumerate() {
+        match webidl::argument::<webidl::UnrestrictedDouble>(
+            scope,
+            args,
+            index as i32,
+            webidl::Context::argument(prefix, index + 1),
+        ) {
+            Ok(parsed) => *value = parsed.0,
+            Err(error) => {
+                webidl::throw_error(scope, &error);
+                return None;
+            }
+        }
+    }
+    Some(values)
+}
+
+pub(super) fn set_transform_arguments<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    args: &v8::FunctionCallbackArguments<'s>,
+) -> Option<[f64; 6]> {
+    const PREFIX: &str = "CanvasRenderingContext2D.setTransform";
+    if args.length() > 1 {
+        return transform_arguments(scope, args, PREFIX);
+    }
+    let init = match webidl::parse_dictionary::<TransformInit>(
+        scope,
+        args.get(0),
+        webidl::Context::argument(PREFIX, 1),
+    ) {
+        Ok(init) => init.unwrap_or_default(),
+        Err(error) => {
+            webidl::throw_error(scope, &error);
+            return None;
+        }
+    };
+    let pairs = [
+        (init.a, init.m11, 1.0),
+        (init.b, init.m12, 0.0),
+        (init.c, init.m21, 0.0),
+        (init.d, init.m22, 1.0),
+        (init.e, init.m41, 0.0),
+        (init.f, init.m42, 0.0),
+    ];
+    let mut values = [0.0; 6];
+    for (value, (alias, component, default)) in values.iter_mut().zip(pairs) {
+        if let (Some(a), Some(b)) = (alias, component)
+            && a != b
+            && !(a.is_nan() && b.is_nan())
+        {
+            throw_type_error(scope, "DOMMatrix2DInit contains inconsistent aliases");
+            return None;
+        }
+        *value = alias.or(component).unwrap_or(default);
+    }
+    Some(values)
+}

--- a/moli-renderer-v8/src/context_bootstrap/media_file_template.rs
+++ b/moli-renderer-v8/src/context_bootstrap/media_file_template.rs
@@ -292,7 +292,7 @@ struct CanvasRenderingContext2dTemplateDeclaration {
 
     #[webapi(
         method = "setTransform",
-        length = 6,
+        length = 0,
         callback = canvas_context_set_transform_callback
     )]
     set_transform: (),

--- a/moli-renderer-v8/src/script_vm/tests/canvas_arguments.rs
+++ b/moli-renderer-v8/src/script_vm/tests/canvas_arguments.rs
@@ -1,0 +1,177 @@
+use super::{canvas_paths::canvas_pixels, *};
+
+fn check(script: &str, expected: &str) {
+    for constructor in [
+        "document.createElement('canvas')",
+        "new OffscreenCanvas(96,96)",
+    ] {
+        let mut vm = new_storage_test_vm("https://canvas-arguments.test/");
+        let result = vm
+            .eval(&format!(
+                r#"(() => {{
+          const canvas={constructor};canvas.width=canvas.height=96;
+          const ctx=canvas.getContext('2d');
+          const caught=f=>{{try{{f();return 'ok';}}catch(e){{return e.name;}}}};
+          {script}
+        }})()"#
+            ))
+            .unwrap();
+        assert_eq!(result, expected, "{constructor}: {script}");
+    }
+}
+
+#[test]
+fn canvas_line_width_and_miter_limit_ignore_nonpositive_or_nonfinite_values() {
+    check(
+        r#"
+      ctx.lineWidth=8;ctx.miterLimit=7;
+      for(const n of [0,-0,-1,NaN,Infinity,-Infinity]) {
+        ctx.lineWidth=n;ctx.miterLimit=n;
+        if(ctx.lineWidth!==8||ctx.miterLimit!==7)throw Error('invalid setter changed state');
+      }
+      ctx.lineWidth={valueOf(){return 0;}};ctx.miterLimit='0';
+      return JSON.stringify([ctx.lineWidth,ctx.miterLimit]);
+    "#,
+        "[8,7]",
+    );
+}
+
+#[test]
+fn canvas_transform_dictionary_and_dommatrix_overloads_record_the_same_geometry() {
+    for init in [
+        "{e:20}",
+        "{m41:20}",
+        "{a:1,m11:1,e:20,m41:20}",
+        "new DOMMatrix([1,0,0,1,20,0])",
+    ] {
+        canvas_pixels(
+            &format!("ctx.setTransform({init});ctx.rect(0,0,10,10);ctx.fill();"),
+            &[(5, 5), (25, 5)],
+            &[0, 255],
+        );
+    }
+}
+
+#[test]
+fn canvas_set_transform_default_dictionary_resets_to_identity() {
+    for init in ["", "undefined", "null", "{}"] {
+        canvas_pixels(
+            &format!(
+                "ctx.translate(20,0);ctx.setTransform({init});ctx.rect(0,0,10,10);ctx.fill();"
+            ),
+            &[(5, 5), (25, 5)],
+            &[255, 0],
+        );
+    }
+    check(
+        "return JSON.stringify([ctx.setTransform.length,ctx.transform.length]);",
+        "[0,6]",
+    );
+}
+
+#[test]
+fn canvas_transform_dictionary_rejects_each_inconsistent_alias_atomically() {
+    check(
+        r#"
+      ctx.translate(20,0);
+      const results=[];
+      for(const [a,b] of [['a','m11'],['b','m12'],['c','m21'],['d','m22'],['e','m41'],['f','m42']]) {
+        results.push(caught(()=>ctx.setTransform({[a]:1,[b]:2})));
+      }
+      ctx.rect(0,0,10,10);ctx.fill();
+      results.push(ctx.getImageData(25,5,1,1).data[3],ctx.getImageData(5,5,1,1).data[3]);
+      return JSON.stringify(results);
+    "#,
+        r#"["TypeError","TypeError","TypeError","TypeError","TypeError","TypeError",255,0]"#,
+    );
+}
+
+#[test]
+fn canvas_transform_dictionary_reads_members_in_webidl_order() {
+    check(
+        r#"
+      const names=['a','b','c','d','e','f','m11','m12','m21','m22','m41','m42'];
+      const order=[],init={};
+      for(const name of names)Object.defineProperty(init,name,{get(){order.push(name);return undefined;}});
+      ctx.setTransform(init);
+      return JSON.stringify(order);
+    "#,
+        r#"["a","b","c","d","e","f","m11","m12","m21","m22","m41","m42"]"#,
+    );
+}
+
+#[test]
+fn canvas_transform_dictionary_getter_exception_preserves_current_transform() {
+    check(
+        r#"
+      ctx.translate(20,0);
+      let message;
+      try{ctx.setTransform({a:2,get e(){throw Error('dictionary failed');}});}catch(e){message=e.message;}
+      ctx.rect(0,0,10,10);ctx.fill();
+      return JSON.stringify([message,ctx.getImageData(25,5,1,1).data[3],ctx.getImageData(5,5,1,1).data[3]]);
+    "#,
+        r#"["dictionary failed",255,0]"#,
+    );
+}
+
+#[test]
+fn canvas_transform_nonfinite_values_are_ignored_after_alias_validation() {
+    check(
+        r#"
+      ctx.translate(20,0);
+      const results=[caught(()=>ctx.setTransform({a:NaN,m11:NaN})),caught(()=>ctx.setTransform({b:0,m12:-0}))];
+      ctx.translate(20,0);
+      ctx.setTransform(Infinity,0,0,1,0,0);ctx.transform(1,0,0,NaN,0,0);
+      ctx.rotate(NaN);ctx.scale(Infinity,1);ctx.translate(0,Infinity);
+      ctx.rect(0,0,10,10);ctx.fill();
+      results.push(ctx.getImageData(25,5,1,1).data[3],ctx.getImageData(5,5,1,1).data[3]);
+      return JSON.stringify(results);
+    "#,
+        r#"["ok","ok",255,0]"#,
+    );
+}
+
+#[test]
+fn canvas_transform_overloads_reject_invalid_arity_and_primitives() {
+    check(
+        r#"
+      return JSON.stringify([
+        caught(()=>ctx.setTransform(1)),caught(()=>ctx.setTransform('matrix(1,0,0,1,0,0)')),
+        caught(()=>ctx.setTransform(1,0)),caught(()=>ctx.setTransform(1,0,0,1,0)),
+        caught(()=>ctx.transform()),caught(()=>ctx.setTransform(1,0,0,1,0,0))
+      ]);
+    "#,
+        r#"["TypeError","TypeError","TypeError","TypeError","TypeError","ok"]"#,
+    );
+}
+
+#[test]
+fn canvas_arc_argument_validation_ignores_nonfinite_before_negative_radius() {
+    check(
+        r#"
+      return JSON.stringify([
+        caught(()=>ctx.arc(NaN,0,-1,0,1)),caught(()=>ctx.arc(0,0,-1,0,1)),
+        caught(()=>ctx.ellipse(0,0,-1,2,Infinity,0,1)),caught(()=>ctx.ellipse(0,0,-1,2,0,0,1)),
+        caught(()=>ctx.arcTo(0,0,NaN,1,-1)),caught(()=>ctx.arcTo(0,0,1,1,-1))
+      ]);
+    "#,
+        r#"["ok","IndexSizeError","ok","IndexSizeError","ok","IndexSizeError"]"#,
+    );
+}
+
+#[test]
+fn canvas_hex_alpha_is_accepted_and_preserved_for_fill_and_stroke() {
+    for color in ["#0f08", "#00ff0088", "#0F08", "rgba(0,255,0,0.533)"] {
+        check(
+            &format!(
+                r#"
+          ctx.fillStyle='{color}';ctx.strokeStyle='{color}';
+          ctx.rect(0,0,10,10);ctx.fill();ctx.beginPath();
+          ctx.lineWidth=2;ctx.moveTo(20,20);ctx.lineTo(40,20);ctx.stroke();
+          return JSON.stringify([Array.from(ctx.getImageData(5,5,1,1).data),Array.from(ctx.getImageData(25,20,1,1).data)]);
+        "#
+            ),
+            "[[0,255,0,136],[0,255,0,136]]",
+        );
+    }
+}

--- a/moli-renderer-v8/src/script_vm/tests/canvas_paths.rs
+++ b/moli-renderer-v8/src/script_vm/tests/canvas_paths.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-fn canvas_pixels(script: &str, points: &[(u32, u32)], expected: &[u8]) {
+pub(super) fn canvas_pixels(script: &str, points: &[(u32, u32)], expected: &[u8]) {
     for kind in ["html", "offscreen"] {
         let mut vm = new_storage_test_vm("https://canvas-paths.test/");
         let result = vm

--- a/moli-renderer-v8/src/script_vm/tests/canvas_paths.rs
+++ b/moli-renderer-v8/src/script_vm/tests/canvas_paths.rs
@@ -1,0 +1,148 @@
+use super::*;
+
+fn canvas_pixels(script: &str, points: &[(u32, u32)], expected: &[u8]) {
+    for kind in ["html", "offscreen"] {
+        let mut vm = new_storage_test_vm("https://canvas-paths.test/");
+        let result = vm
+            .eval(&format!(
+                r#"(() => {{
+                  const canvas = {constructor};
+                  canvas.width = canvas.height = 96;
+                  const ctx = canvas.getContext('2d');
+                  ctx.fillStyle = ctx.strokeStyle = 'red';
+                  ctx.lineWidth = 2;
+                  {script}
+                  return JSON.stringify({points}.map(([x,y]) => ctx.getImageData(x,y,1,1).data[3]));
+                }})()"#,
+                constructor = if kind == "html" {
+                    "document.createElement('canvas')"
+                } else {
+                    "new OffscreenCanvas(96,96)"
+                },
+                points = serde_json::to_string(points).unwrap(),
+            ))
+            .expect("canvas script should execute");
+        assert_eq!(
+            result,
+            serde_json::to_string(expected).unwrap(),
+            "{kind}: {script}"
+        );
+    }
+}
+
+#[test]
+fn canvas_arc_quadrants_match_screen_coordinate_direction() {
+    // Pixel probes exclude the antialiased boundary; Chromium 145 gives these
+    // same results. Checking only the center misses malformed circular paths.
+    let points = [(40, 40), (24, 40), (24, 24), (40, 24)];
+    canvas_pixels(
+        "ctx.moveTo(32,32);ctx.arc(32,32,20,0,Math.PI/2);ctx.closePath();ctx.fill();",
+        &points,
+        &[255, 0, 0, 0],
+    );
+    canvas_pixels(
+        "ctx.moveTo(32,32);ctx.arc(32,32,20,0,-Math.PI/2,true);ctx.closePath();ctx.fill();",
+        &points,
+        &[0, 0, 0, 255],
+    );
+    canvas_pixels(
+        "ctx.moveTo(32,32);ctx.arc(32,32,20,0,Math.PI/2,true);ctx.closePath();ctx.fill();",
+        &points,
+        &[0, 255, 255, 255],
+    );
+}
+
+#[test]
+fn canvas_full_circle_matches_a_disk_away_from_its_boundary() {
+    let mut points = Vec::new();
+    let mut expected = Vec::new();
+    for y in (5..60).step_by(2) {
+        for x in (5..60).step_by(2) {
+            let distance = (f64::from(x) + 0.5 - 32.0).hypot(f64::from(y) + 0.5 - 32.0);
+            if (distance - 20.0).abs() > 2.0 {
+                points.push((x, y));
+                expected.push(if distance < 20.0 { 255 } else { 0 });
+            }
+        }
+    }
+    for arc in [
+        "0,2*Math.PI",
+        "0,-2*Math.PI,true",
+        "0,4*Math.PI",
+        "1,1+2*Math.PI",
+    ] {
+        canvas_pixels(
+            &format!("ctx.arc(32,32,20,{arc});ctx.fill();"),
+            &points,
+            &expected,
+        );
+    }
+}
+
+#[test]
+fn canvas_ellipse_preserves_center_and_rotation() {
+    canvas_pixels(
+        "ctx.ellipse(32,32,20,10,0,0,2*Math.PI);ctx.fill();",
+        &[(48, 32), (32, 39), (32, 45), (32, 32)],
+        &[255, 255, 0, 255],
+    );
+    canvas_pixels(
+        "ctx.ellipse(32,32,20,10,Math.PI/2,0,2*Math.PI);ctx.fill();",
+        &[(32, 48), (39, 32), (45, 32), (32, 32)],
+        &[255, 255, 0, 255],
+    );
+}
+
+#[test]
+fn canvas_arc_to_connects_to_the_first_tangent() {
+    canvas_pixels(
+        "ctx.moveTo(0,20);ctx.arcTo(40,20,40,60,15);ctx.stroke();",
+        &[(10, 20), (25, 20), (39, 34), (48, 20), (39, 50)],
+        &[255, 255, 255, 0, 0],
+    );
+}
+
+#[test]
+fn canvas_arc_to_does_not_clamp_radius_to_segment_lengths() {
+    canvas_pixels(
+        "ctx.moveTo(10,20);ctx.arcTo(40,20,40,30,25);ctx.stroke();",
+        &[(14, 20), (39, 44), (39, 30), (39, 25)],
+        &[255, 255, 0, 0],
+    );
+}
+
+#[test]
+fn canvas_empty_path_commands_establish_the_required_start_point() {
+    for command in [
+        "ctx.lineTo(10,10);",
+        "ctx.quadraticCurveTo(10,10,10,10);",
+        "ctx.bezierCurveTo(10,10,10,10,10,10);",
+        "ctx.arcTo(10,10,20,20,5);",
+    ] {
+        canvas_pixels(
+            &format!("{command}ctx.lineTo(30,10);ctx.lineTo(30,30);ctx.closePath();ctx.fill();"),
+            &[(25, 15), (15, 25)],
+            &[255, 0],
+        );
+    }
+}
+
+#[test]
+fn canvas_zero_radius_arc_keeps_its_connecting_line() {
+    canvas_pixels(
+        "ctx.moveTo(5,20);ctx.arc(30,20,0,0,1);ctx.stroke();",
+        &[(15, 20), (35, 20)],
+        &[255, 0],
+    );
+}
+
+#[test]
+fn canvas_arc_to_degenerate_segments_remain_lines() {
+    for arguments in ["30,20,50,20,8", "30,20,30,20,8", "30,20,30,40,0"] {
+        canvas_pixels(
+            &format!("ctx.moveTo(5,20);ctx.arcTo({arguments});ctx.stroke();"),
+            &[(15, 20), (35, 20)],
+            &[255, 0],
+        );
+    }
+}

--- a/moli-renderer-v8/src/script_vm/tests/canvas_paths.rs
+++ b/moli-renderer-v8/src/script_vm/tests/canvas_paths.rs
@@ -217,3 +217,138 @@ fn canvas_path_state_is_independent_between_contexts_and_after_reset() {
       return JSON.stringify([x.getImageData(5,5,1,1).data[3],y.getImageData(15,15,1,1).data[3],y.getImageData(5,5,1,1).data[3]]);
     })()"#).unwrap(),"[0,255,0]");
 }
+
+#[test]
+fn canvas_later_transforms_do_not_move_recorded_geometry() {
+    for transform in [
+        "ctx.translate(20,0)",
+        "ctx.scale(2,3)",
+        "ctx.rotate(Math.PI/2)",
+    ] {
+        canvas_pixels(
+            &format!("ctx.rect(5,5,10,10);{transform};ctx.fill();"),
+            &[(10, 10), (30, 10), (20, 30)],
+            &[255, 0, 0],
+        );
+    }
+}
+
+#[test]
+fn canvas_path_records_each_commands_coordinate_system() {
+    canvas_pixels(
+        "ctx.rect(0,0,10,10);ctx.translate(20,0);ctx.rect(0,0,10,10);ctx.resetTransform();ctx.fill();",
+        &[(5, 5), (25, 5), (45, 5)],
+        &[255, 255, 0],
+    );
+    // Adapted from WPT 2d.path.transformation.changing. The final CTM must
+    // not be applied a second time to the previously recorded rectangle.
+    canvas_pixels(
+        "ctx.moveTo(0,0);ctx.translate(40,0);ctx.lineTo(0,0);ctx.translate(0,40);ctx.lineTo(0,0);ctx.translate(-40,0);ctx.lineTo(0,0);ctx.translate(1000,1000);ctx.rotate(Math.PI/2);ctx.scale(.1,.1);ctx.fill();",
+        &[(20, 20), (50, 50)],
+        &[255, 0],
+    );
+}
+
+#[test]
+fn canvas_current_transform_changes_stroke_metrics_not_path_position() {
+    // Same contract as WPT 2d.path.stroke.scale1/scale2, without depending on
+    // the separately unsupported save/restore implementation.
+    canvas_pixels(
+        "ctx.moveTo(10,20);ctx.lineTo(30,20);ctx.scale(2,3);ctx.lineWidth=4;ctx.stroke();",
+        &[(15, 15), (15, 20), (15, 25), (15, 27), (40, 60)],
+        &[255, 255, 255, 0, 0],
+    );
+    canvas_pixels(
+        "ctx.moveTo(10,20);ctx.lineTo(30,20);ctx.rotate(Math.PI/2);ctx.scale(3,2);ctx.lineWidth=4;ctx.stroke();",
+        &[(15, 15), (15, 20), (15, 25), (15, 27)],
+        &[255, 255, 255, 0],
+    );
+}
+
+#[test]
+fn canvas_stroke_dashes_follow_the_current_transform() {
+    canvas_pixels(
+        "ctx.moveTo(10,20);ctx.lineTo(90,20);ctx.scale(2,1);ctx.setLineDash([10,10]);ctx.stroke();",
+        &[
+            (15, 20),
+            (25, 20),
+            (35, 20),
+            (45, 20),
+            (55, 20),
+            (65, 20),
+            (75, 20),
+        ],
+        &[255, 255, 0, 0, 255, 255, 0],
+    );
+}
+
+#[test]
+fn canvas_arc_to_resolves_the_old_point_in_the_new_user_space() {
+    canvas_pixels(
+        "ctx.moveTo(10,20);ctx.translate(20,0);ctx.arcTo(20,20,20,50,10);ctx.stroke();",
+        &[(15, 20), (30, 20), (39, 29), (50, 20)],
+        &[255, 255, 255, 0],
+    );
+}
+
+#[test]
+fn canvas_continuing_a_closed_subpath_does_not_transform_its_start_again() {
+    canvas_pixels(
+        "ctx.moveTo(5,5);ctx.lineTo(15,5);ctx.lineTo(15,15);ctx.closePath();ctx.translate(20,0);ctx.lineTo(-15,25);ctx.stroke();",
+        &[(5, 20), (25, 20)],
+        &[255, 0],
+    );
+}
+
+#[test]
+fn canvas_stroke_rect_uses_current_transform_without_changing_default_path() {
+    canvas_pixels(
+        "ctx.rect(5,5,10,10);ctx.translate(20,0);ctx.strokeRect(0,30,10,10);ctx.resetTransform();ctx.fill();",
+        &[(10, 10), (25, 35), (20, 35)],
+        &[255, 0, 255],
+    );
+}
+
+#[test]
+fn canvas_singular_transform_suppresses_paint_without_losing_the_old_path() {
+    canvas_pixels(
+        "ctx.rect(5,5,10,10);ctx.scale(0,1);ctx.fill();ctx.stroke();",
+        &[(10, 10)],
+        &[0],
+    );
+    canvas_pixels(
+        "ctx.rect(5,5,10,10);ctx.scale(0,1);ctx.fill();ctx.resetTransform();ctx.fill();",
+        &[(10, 10)],
+        &[255],
+    );
+}
+
+#[test]
+fn canvas_small_invertible_scale_is_not_treated_as_singular() {
+    canvas_pixels(
+        "ctx.scale(1e-9,1e-9);ctx.rect(0,0,1e10,1e10);ctx.fill();",
+        &[(5, 5), (15, 5)],
+        &[255, 0],
+    );
+}
+
+#[test]
+fn canvas_curves_are_transformed_when_recorded() {
+    for curve in [
+        "ctx.quadraticCurveTo(5,0,10,0)",
+        "ctx.bezierCurveTo(3,0,7,0,10,0)",
+    ] {
+        canvas_pixels(
+            &format!(
+                "ctx.translate(10,20);ctx.moveTo(0,0);{curve};ctx.resetTransform();ctx.stroke();"
+            ),
+            &[(15, 20), (15, 0)],
+            &[255, 0],
+        );
+    }
+    canvas_pixels(
+        "ctx.translate(20,20);ctx.arc(12,12,10,0,2*Math.PI);ctx.resetTransform();ctx.fill();",
+        &[(32, 32), (12, 12)],
+        &[255, 0],
+    );
+}

--- a/moli-renderer-v8/src/script_vm/tests/canvas_paths.rs
+++ b/moli-renderer-v8/src/script_vm/tests/canvas_paths.rs
@@ -146,3 +146,74 @@ fn canvas_arc_to_degenerate_segments_remain_lines() {
         );
     }
 }
+
+#[test]
+fn canvas_resize_discards_the_current_path_even_when_size_is_unchanged() {
+    for assignment in [
+        "canvas.width=canvas.width",
+        "canvas.height=canvas.height",
+        "canvas.width=64",
+        "canvas.height=0;canvas.height=96",
+    ] {
+        canvas_pixels(
+            &format!("ctx.rect(0,0,10,10);{assignment};ctx.fill();"),
+            &[(5, 5)],
+            &[0],
+        );
+    }
+}
+
+#[test]
+fn canvas_dimension_attribute_mutation_resets_path_and_transform() {
+    let mut vm = new_storage_test_vm("https://canvas-reset.test/");
+    let result = vm.eval(r#"(() => {
+      const canvas = document.createElement('canvas');
+      canvas.width=96;canvas.height=96;
+      const ctx=canvas.getContext('2d');
+      ctx.translate(30,0);ctx.rect(0,0,10,10);
+      canvas.setAttribute('width','96');
+      ctx.fill();
+      const old=ctx.getImageData(35,5,1,1).data[3];
+      ctx.rect(0,0,10,10);ctx.fill();
+      return JSON.stringify([old,ctx.getImageData(5,5,1,1).data[3],ctx.getImageData(35,5,1,1).data[3]]);
+    })()"#).unwrap();
+    assert_eq!(result, "[0,255,0]");
+}
+
+#[test]
+fn canvas_resize_resets_all_implemented_drawing_state_without_replacing_context() {
+    for constructor in [
+        "document.createElement('canvas')",
+        "new OffscreenCanvas(96,96)",
+    ] {
+        let mut vm = new_storage_test_vm("https://canvas-state.test/");
+        let result=vm.eval(&format!(r#"(() => {{
+          const canvas={constructor},ctx=canvas.getContext('2d');
+          ctx.fillStyle='red';ctx.strokeStyle='blue';ctx.font='30px serif';
+          ctx.lineWidth=8;ctx.miterLimit=4;ctx.lineCap='round';ctx.lineJoin='bevel';
+          ctx.lineDashOffset=3;ctx.setLineDash([2,3]);ctx.globalAlpha=.5;
+          ctx.globalCompositeOperation='copy';ctx.imageSmoothingEnabled=false;
+          ctx.imageSmoothingQuality='high';ctx.translate(20,0);
+          canvas.height=canvas.height;
+          return JSON.stringify([ctx===canvas.getContext('2d'),ctx.fillStyle,ctx.strokeStyle,ctx.font,
+            ctx.lineWidth,ctx.miterLimit,ctx.lineCap,ctx.lineJoin,ctx.lineDashOffset,ctx.getLineDash(),
+            ctx.globalAlpha,ctx.globalCompositeOperation,ctx.imageSmoothingEnabled,ctx.imageSmoothingQuality]);
+        }})()"#)).unwrap();
+        assert_eq!(
+            result,
+            r##"[true,"#000000","#000000","10px sans-serif",1,10,"butt","miter",0,[],1,"source-over",true,"low"]"##
+        );
+    }
+}
+
+#[test]
+fn canvas_path_state_is_independent_between_contexts_and_after_reset() {
+    let mut vm = new_storage_test_vm("https://canvas-independent.test/");
+    assert_eq!(vm.eval(r#"(() => {
+      const a=new OffscreenCanvas(20,20), b=new OffscreenCanvas(20,20);
+      const x=a.getContext('2d'),y=b.getContext('2d');
+      x.rect(0,0,10,10);y.rect(10,10,10,10);a.width=20;
+      x.fill();y.fill();
+      return JSON.stringify([x.getImageData(5,5,1,1).data[3],y.getImageData(15,15,1,1).data[3],y.getImageData(5,5,1,1).data[3]]);
+    })()"#).unwrap(),"[0,255,0]");
+}

--- a/moli-renderer-v8/src/script_vm/tests/mod.rs
+++ b/moli-renderer-v8/src/script_vm/tests/mod.rs
@@ -15145,6 +15145,7 @@ fn decode_png_dimensions_from_data_url(data_url: &str) -> (u32, u32) {
 }
 
 mod browser_api;
+mod canvas_arguments;
 mod canvas_paths;
 mod canvas_webgl;
 mod dom_elements;

--- a/moli-renderer-v8/src/script_vm/tests/mod.rs
+++ b/moli-renderer-v8/src/script_vm/tests/mod.rs
@@ -15145,6 +15145,7 @@ fn decode_png_dimensions_from_data_url(data_url: &str) -> (u32, u32) {
 }
 
 mod browser_api;
+mod canvas_paths;
 mod canvas_webgl;
 mod dom_elements;
 mod dom_xhr;


### PR DESCRIPTION
CanvasRenderingContext2D path drawing was a no-op: every path method
(beginPath, moveTo, lineTo, quadraticCurveTo, bezierCurveTo, arcTo, arc,
ellipse, rect, fill, stroke, strokeRect) was wired to an empty callback, so
path-based charts/icons rendered no pixels in screenshots while fillRect and
putImageData worked.

Implement a per-context current-path state and rasterize it through the
existing moli_paint::raster_snapshot (vello CPU) pipeline:

- Build the current default path from the canvas path commands, converting
  arc()/ellipse()/arcTo() to cubic Beziers, and apply the 2D transform
  (translate/scale/rotate/transform/setTransform/resetTransform) to the
  geometry.
- fill()/stroke() construct a PaintSnapshot fill/stroke fragment (nonzero
  winding) and source-over composite the premultiplied raster over the
  canvas backing store, honoring globalAlpha and the new stroke state
  (lineWidth, lineCap, lineJoin, miterLimit, lineDash, lineDashOffset,
  strokeStyle).
- strokeRect() strokes a rect without mutating the current path.

Also extend moli_canvas fill-style parsing: the old parser only accepted
black/red/rebeccapurple and #hex, so fillStyle='blue' or strokeStyle='green'
silently rendered black. Add the full CSS named-color table, rgb()/rgba()
with percentage channels, transparent, and 3/4/6/8-digit hex.

Tests cover arc+fill, lineTo+stroke, rect+fill, translate, and lineWidth,
asserting exact pixels via getImageData; the prior fingerprinting test that
asserted paths did not change the canvas now expects them to render.