### PR TITLE
perf(cdp): defer default target runtime creation

### DIFF
--- a/moli-protocol-server/src/cdp_frontend.rs
+++ b/moli-protocol-server/src/cdp_frontend.rs
@@ -48,7 +48,7 @@ pub(crate) enum CdpFrontendControlRequest {
         target_url: String,
         completion_tx: oneshot::Sender<Result<CdpCreatedTarget>>,
     },
-    EnsureDefaultTarget {
+    EnsureDefaultTargetPublished {
         completion_tx: oneshot::Sender<Result<()>>,
     },
     Shutdown,
@@ -212,13 +212,13 @@ impl CdpFrontendEndpoint {
         }
     }
 
-    pub(crate) async fn ensure_default_target(&self) -> Result<()> {
+    pub(crate) async fn ensure_default_target_published(&self) -> Result<()> {
         if self.is_shutting_down() {
             bail!("CDP target owner is shutting down");
         }
         let (completion_tx, completion_rx) = oneshot::channel();
         self.control_tx
-            .send(CdpFrontendControlRequest::EnsureDefaultTarget { completion_tx })
+            .send(CdpFrontendControlRequest::EnsureDefaultTargetPublished { completion_tx })
             .context("CDP owner is no longer available")?;
         tokio::select! {
             biased;

--- a/moli-protocol-server/src/cdp_scheduler.rs
+++ b/moli-protocol-server/src/cdp_scheduler.rs
@@ -118,6 +118,12 @@ pub(crate) struct CdpScheduler {
     page_screencasts: HashMap<Option<String>, PageScreencastSchedule>,
 }
 
+#[derive(Clone, Copy)]
+enum DefaultTargetRuntimeInitialization {
+    Materialized,
+    Deferred,
+}
+
 impl CdpScheduler {
     pub(crate) fn page_residence_identity_for_devtools_context(
         &mut self,
@@ -715,16 +721,59 @@ impl CdpScheduler {
         navigation_runtime_config: NavigationRuntimeConfig,
         target_host_integration: Option<CdpTargetHostIntegration>,
     ) -> (Self, CdpSchedulerEventReceivers) {
-        let mut scheduler = Self::new(
-            CdpConnection::new_with_initial_storage_partition_and_runtime_config(
-                initial_storage_partition,
-                navigation_runtime_config,
-            ),
-        );
+        Self::new_with_default_target_runtime_initialization(
+            initial_storage_partition,
+            navigation_runtime_config,
+            target_host_integration,
+            DefaultTargetRuntimeInitialization::Materialized,
+        )
+    }
+
+    pub(crate) fn new_with_deferred_default_target_runtime(
+        initial_storage_partition: CdpInitialStoragePartition,
+        navigation_runtime_config: NavigationRuntimeConfig,
+        target_host_integration: Option<CdpTargetHostIntegration>,
+    ) -> (Self, CdpSchedulerEventReceivers) {
+        Self::new_with_default_target_runtime_initialization(
+            initial_storage_partition,
+            navigation_runtime_config,
+            target_host_integration,
+            DefaultTargetRuntimeInitialization::Deferred,
+        )
+    }
+
+    fn new_with_default_target_runtime_initialization(
+        initial_storage_partition: CdpInitialStoragePartition,
+        navigation_runtime_config: NavigationRuntimeConfig,
+        target_host_integration: Option<CdpTargetHostIntegration>,
+        initialization: DefaultTargetRuntimeInitialization,
+    ) -> (Self, CdpSchedulerEventReceivers) {
+        let conn = match initialization {
+            DefaultTargetRuntimeInitialization::Materialized => {
+                CdpConnection::new_with_initial_storage_partition_and_runtime_config(
+                    initial_storage_partition,
+                    navigation_runtime_config,
+                )
+            }
+            DefaultTargetRuntimeInitialization::Deferred => {
+                CdpConnection::new_with_deferred_navigation_runtime(
+                    initial_storage_partition,
+                    navigation_runtime_config,
+                )
+            }
+        };
+        let mut scheduler = Self::new(conn);
         if let Some(target_host_integration) = target_host_integration {
             target_host_integration.install(&mut scheduler.conn);
         }
-        scheduler.conn.install_default_browser_target();
+        match initialization {
+            DefaultTargetRuntimeInitialization::Materialized => {
+                scheduler.conn.install_default_browser_target();
+            }
+            DefaultTargetRuntimeInitialization::Deferred => {
+                scheduler.conn.publish_default_browser_target();
+            }
+        }
         scheduler.conn.enable_default_target_on_auto_attach();
         let (background_event_tx, background_event_rx) = mpsc::unbounded_channel();
         scheduler

--- a/moli-protocol-server/src/cdp_scheduler/frontend_control.rs
+++ b/moli-protocol-server/src/cdp_scheduler/frontend_control.rs
@@ -202,12 +202,10 @@ impl CdpFrontendControlState {
                 send_cookie_checkpoint(scheduler, owner_lifecycle);
                 true
             }
-            CdpFrontendControlRequest::EnsureDefaultTarget { completion_tx } => {
-                let result = self
-                    .target_control
-                    .ensure_default_target_is_materialized(scheduler, frontend_router)
-                    .await;
-                let _ = completion_tx.send(result);
+            CdpFrontendControlRequest::EnsureDefaultTargetPublished { completion_tx } => {
+                self.target_control
+                    .ensure_default_target_is_published(scheduler);
+                let _ = completion_tx.send(Ok(()));
                 true
             }
             CdpFrontendControlRequest::Shutdown => false,

--- a/moli-protocol-server/src/cdp_scheduler/frontend_control/target_control.rs
+++ b/moli-protocol-server/src/cdp_scheduler/frontend_control/target_control.rs
@@ -8,7 +8,6 @@ use super::super::{CdpScheduler, ProtocolOutputSequence};
 pub(super) struct CdpFrontendTargetControl {
     next_command_id: u64,
     browser_control_session_id: Option<String>,
-    default_page_materialized: bool,
 }
 
 impl Default for CdpFrontendTargetControl {
@@ -16,7 +15,6 @@ impl Default for CdpFrontendTargetControl {
         Self {
             next_command_id: u64::MAX,
             browser_control_session_id: None,
-            default_page_materialized: false,
         }
     }
 }
@@ -28,10 +26,6 @@ impl CdpFrontendTargetControl {
         frontend_router: &CdpFrontendRouter,
         target_id: &str,
     ) -> Result<String> {
-        if target_id == scheduler.conn.default_tab_target_id() {
-            self.ensure_default_target_is_materialized(scheduler, frontend_router)
-                .await?;
-        }
         self.attach_target_session(scheduler, frontend_router, target_id)
             .await
     }
@@ -58,9 +52,6 @@ impl CdpFrontendTargetControl {
             .as_str()
             .with_context(|| format!("CDP target {target_id} did not return an attach session"))?
             .to_owned();
-        if target_id == scheduler.conn.default_target_id() {
-            self.default_page_materialized = true;
-        }
         Ok(session_id)
     }
 
@@ -69,8 +60,6 @@ impl CdpFrontendTargetControl {
         scheduler: &mut CdpScheduler,
         frontend_router: &CdpFrontendRouter,
     ) -> Result<String> {
-        self.ensure_default_target_is_materialized(scheduler, frontend_router)
-            .await?;
         let response = self
             .execute_command(
                 scheduler,
@@ -129,8 +118,6 @@ impl CdpFrontendTargetControl {
         frontend_router: &CdpFrontendRouter,
         target_url: &str,
     ) -> Result<CdpCreatedTarget> {
-        self.ensure_default_target_is_materialized(scheduler, frontend_router)
-            .await?;
         let response = self
             .execute_command(
                 scheduler,
@@ -201,44 +188,8 @@ impl CdpFrontendTargetControl {
         Ok(session_id)
     }
 
-    pub(super) async fn ensure_default_target_is_materialized(
-        &mut self,
-        scheduler: &mut CdpScheduler,
-        frontend_router: &CdpFrontendRouter,
-    ) -> Result<()> {
-        if self.default_page_materialized {
-            return Ok(());
-        }
-        // A fresh connection may reuse its unclaimed default placeholder for
-        // the first createTarget. The protocol server publishes that default
-        // ID permanently, so materialize it before creating another target.
-        let default_target_id = scheduler.conn.default_target_id().to_owned();
-        let control_session_id = self
-            .ensure_browser_control_session(scheduler, frontend_router)
-            .await?;
-        let response = self
-            .execute_command(
-                scheduler,
-                frontend_router,
-                Some(&control_session_id),
-                "Target.attachToTarget",
-                json!({ "targetId": default_target_id, "flatten": true }),
-            )
-            .await?;
-        let reservation_session_id = response["result"]["sessionId"]
-            .as_str()
-            .context("default target reservation returned no sessionId")?
-            .to_owned();
-        self.execute_command(
-            scheduler,
-            frontend_router,
-            Some(&control_session_id),
-            "Target.detachFromTarget",
-            json!({ "sessionId": reservation_session_id }),
-        )
-        .await?;
-        self.default_page_materialized = true;
-        Ok(())
+    pub(super) fn ensure_default_target_is_published(&mut self, scheduler: &mut CdpScheduler) {
+        scheduler.conn.publish_default_browser_target();
     }
 
     async fn execute_command(

--- a/moli-protocol-server/src/protocol_server/cdp.rs
+++ b/moli-protocol-server/src/protocol_server/cdp.rs
@@ -212,7 +212,7 @@ async fn ensure_default_target_is_published(state: &AppState) -> Result<(), Stri
         .shared_owner()
         .map_err(|error| error.to_string())?;
     endpoint
-        .ensure_default_target()
+        .ensure_default_target_published()
         .await
         .map_err(|error| error.to_string())
 }

--- a/moli-protocol-server/src/protocol_server/cdp_owner.rs
+++ b/moli-protocol-server/src/protocol_server/cdp_owner.rs
@@ -206,7 +206,7 @@ fn spawn_owner_task(
 ) -> oneshot::Receiver<()> {
     spawn_protocol_local_task("cdp-owner", move || async move {
         let (scheduler, scheduler_receivers) =
-            CdpScheduler::new_with_initial_state_runtime_config_and_target_host_integration(
+            CdpScheduler::new_with_deferred_default_target_runtime(
                 initial_storage_partition,
                 navigation_runtime_config,
                 target_host_integration,

--- a/moli-protocol/src/conn.rs
+++ b/moli-protocol/src/conn.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::OnceCell,
     collections::{HashMap, HashSet},
     path::PathBuf,
     sync::{
@@ -117,7 +118,10 @@ pub use moli_protocol_cdp::{
     CdpRendererCommandAccess, CdpRendererCommandPolicy, CdpRendererCommandReplacement,
     CdpRendererCommandReplayDispatch, CdpRequest, ParsedCdpCommand,
 };
-pub(crate) use target::{CdpSessionRoute, TargetActivationTransition, TargetHandlerAccessMode};
+use target::DEFAULT_BROWSER_CONTEXT_ID;
+pub(crate) use target::{
+    CdpSessionRoute, DefaultTargetLifecycle, TargetActivationTransition, TargetHandlerAccessMode,
+};
 
 #[derive(Clone, Debug)]
 pub enum CdpTargetHostLifecycleDelta {
@@ -1045,42 +1049,100 @@ pub(crate) struct ServiceWorkerAutoAttachRelatedOwnerSession {
 /// BrowserContext network roots. A plain field would only be dropped after the
 /// Drop implementation returned, which reverses that order.
 struct NavigationEngineOwnerSlot {
-    engine: Option<NavigationEngine>,
+    engine: OnceCell<NavigationEngine>,
+    runtime_config: NavigationRuntimeConfig,
+    renderer_publication_sender: Option<moli_core::RendererOutputTransportSender>,
 }
 
 impl NavigationEngineOwnerSlot {
-    fn new(engine: NavigationEngine) -> Self {
+    fn materialized(engine: NavigationEngine) -> Self {
+        let runtime_config = engine.runtime_config();
+        let slot = Self {
+            engine: OnceCell::new(),
+            runtime_config,
+            renderer_publication_sender: None,
+        };
+        slot.engine
+            .set(engine)
+            .expect("fresh navigation engine slot must be empty");
+        slot
+    }
+
+    fn deferred(runtime_config: NavigationRuntimeConfig) -> Self {
         Self {
-            engine: Some(engine),
+            engine: OnceCell::new(),
+            runtime_config,
+            renderer_publication_sender: None,
         }
     }
 
-    fn replace(&mut self, engine: NavigationEngine) -> NavigationEngine {
+    #[cfg(test)]
+    fn is_materialized(&self) -> bool {
+        self.engine.get().is_some()
+    }
+
+    fn runtime_config(&self) -> NavigationRuntimeConfig {
         self.engine
-            .replace(engine)
-            .expect("CDP active navigation engine was already taken")
+            .get()
+            .map(NavigationEngine::runtime_config)
+            .unwrap_or_else(|| self.runtime_config.clone())
+    }
+
+    fn fetch_config(&self) -> &moli_fetch::FetchConfig {
+        self.engine
+            .get()
+            .map(NavigationEngine::fetch_config)
+            .unwrap_or_else(|| self.runtime_config.fetch_config())
+    }
+
+    fn layout_policy(&self) -> LayoutPolicy {
+        self.engine
+            .get()
+            .map(NavigationEngine::layout_policy)
+            .unwrap_or_else(|| self.runtime_config.layout_policy())
+    }
+
+    fn set_renderer_output_transport_sender(
+        &mut self,
+        sender: moli_core::RendererOutputTransportSender,
+    ) {
+        if let Some(engine) = self.engine.get() {
+            engine.set_renderer_output_transport_sender(sender.clone());
+        }
+        self.renderer_publication_sender = Some(sender);
+    }
+
+    fn replace(&mut self, engine: NavigationEngine) -> Option<NavigationEngine> {
+        self.runtime_config = engine.runtime_config();
+        if let Some(sender) = self.renderer_publication_sender.as_ref() {
+            engine.set_renderer_output_transport_sender(sender.clone());
+        }
+        let previous = self.engine.take();
+        self.engine
+            .set(engine)
+            .expect("navigation engine slot must be empty after take");
+        previous
     }
 
     fn take(&mut self) -> Option<NavigationEngine> {
         self.engine.take()
     }
-}
 
-impl std::ops::Deref for NavigationEngineOwnerSlot {
-    type Target = NavigationEngine;
-
-    fn deref(&self) -> &Self::Target {
-        self.engine
-            .as_ref()
-            .expect("CDP active navigation engine was already taken")
+    fn ensure(&self) -> &NavigationEngine {
+        self.engine.get_or_init(|| {
+            let engine = NavigationEngine::new_with_runtime_config(self.runtime_config.clone());
+            if let Some(sender) = self.renderer_publication_sender.as_ref() {
+                engine.set_renderer_output_transport_sender(sender.clone());
+            }
+            engine
+        })
     }
-}
 
-impl std::ops::DerefMut for NavigationEngineOwnerSlot {
-    fn deref_mut(&mut self) -> &mut Self::Target {
+    fn ensure_mut(&mut self) -> &mut NavigationEngine {
+        self.ensure();
         self.engine
-            .as_mut()
-            .expect("CDP active navigation engine was already taken")
+            .get_mut()
+            .expect("navigation engine was just materialized")
     }
 }
 
@@ -1105,6 +1167,7 @@ pub struct CdpConnection {
     pub auto_attach_wait_for_debugger_on_start: bool,
     auto_attach_owner_sessions: HashMap<Option<String>, AutoAttachOwnerPolicy>,
     target_control: TargetControlPlane,
+    default_target_lifecycle: DefaultTargetLifecycle,
     service_worker_auto_attach_related_owners: Vec<ServiceWorkerAutoAttachRelatedOwner>,
     service_worker_pause_on_start_owner_sessions: HashSet<Option<String>>,
     dedicated_worker_pause_on_start_owner_sessions: HashSet<Option<String>>,
@@ -1324,11 +1387,42 @@ impl CdpConnection {
         )
     }
 
+    /// Creates protocol state without starting the renderer runtime.
+    ///
+    /// The runtime is materialized on first engine-backed operation. This is
+    /// intended for browser-level CDP owners that publish a target before any
+    /// frontend attaches to its page.
+    pub fn new_with_deferred_navigation_runtime(
+        initial_storage_partition: CdpInitialStoragePartition,
+        navigation_runtime_config: NavigationRuntimeConfig,
+    ) -> Self {
+        let initial_storage_partition =
+            CdpInitialStoragePartitionOwner::from_initial_storage_partition(
+                initial_storage_partition,
+            );
+        Self::new_with_initial_storage_partition_owner_and_engine(
+            initial_storage_partition,
+            NavigationEngineOwnerSlot::deferred(navigation_runtime_config),
+        )
+    }
+
     fn new_with_initial_storage_partition_owner_and_runtime_config(
         initial_storage_partition: CdpInitialStoragePartitionOwner,
         navigation_runtime_config: NavigationRuntimeConfig,
     ) -> Self {
-        let fetch_config = navigation_runtime_config.fetch_config();
+        Self::new_with_initial_storage_partition_owner_and_engine(
+            initial_storage_partition,
+            NavigationEngineOwnerSlot::materialized(NavigationEngine::new_with_runtime_config(
+                navigation_runtime_config,
+            )),
+        )
+    }
+
+    fn new_with_initial_storage_partition_owner_and_engine(
+        initial_storage_partition: CdpInitialStoragePartitionOwner,
+        engine: NavigationEngineOwnerSlot,
+    ) -> Self {
+        let fetch_config = engine.fetch_config();
         let base_browser_identity = fetch_config.browser_identity().clone();
         let base_http_proxy = fetch_config.http_proxy().map(str::to_owned);
         let base_http_no_proxy = fetch_config.http_no_proxy().map(str::to_owned);
@@ -1344,6 +1438,7 @@ impl CdpConnection {
             auto_attach_wait_for_debugger_on_start: false,
             auto_attach_owner_sessions: HashMap::new(),
             target_control: TargetControlPlane::default(),
+            default_target_lifecycle: DefaultTargetLifecycle::default(),
             service_worker_auto_attach_related_owners: Vec::new(),
             service_worker_pause_on_start_owner_sessions: HashSet::new(),
             dedicated_worker_pause_on_start_owner_sessions: HashSet::new(),
@@ -1381,9 +1476,7 @@ impl CdpConnection {
             target_host_lifecycle_observer: None,
             scheduler_state: CdpConnectionSchedulerState::default(),
             none_session_owner_route_override: None,
-            engine: NavigationEngineOwnerSlot::new(NavigationEngine::new_with_runtime_config(
-                navigation_runtime_config,
-            )),
+            engine,
             retained_background_navigation_engines: HashMap::new(),
         }
     }
@@ -3020,7 +3113,8 @@ impl CdpConnection {
         }
         let retained_background_navigation_engine_count =
             self.retained_background_navigation_engines.len();
-        let active_renderer_owner_id = self.engine.renderer_owner_id_for_diagnostics();
+        let active_engine = self.engine.ensure();
+        let active_renderer_owner_id = active_engine.renderer_owner_id_for_diagnostics();
         let mut retained_background_navigation_engine_renderer_owner_ids = HashSet::new();
         let mut estimated_renderer_owner_ids = HashSet::new();
         estimated_renderer_owner_ids.insert(active_renderer_owner_id);
@@ -3035,10 +3129,11 @@ impl CdpConnection {
         let retained_background_navigation_engine_renderer_owner_count =
             retained_background_navigation_engine_renderer_owner_ids.len();
         let estimated_renderer_owner_count = estimated_renderer_owner_ids.len();
-        let document_isolate_model = self.engine.document_isolate_model_for_diagnostics();
+        let document_isolate_model = active_engine.document_isolate_model_for_diagnostics();
         let estimated_document_isolate_count =
             loaded_document_page_count + pending_document_page_build_count;
-        let document_isolate_accounting = self.engine.document_isolate_accounting_for_diagnostics();
+        let document_isolate_accounting =
+            active_engine.document_isolate_accounting_for_diagnostics();
         let document_isolate_accounting = json!({
             "scope": "renderer-process",
             "created": document_isolate_accounting.created,
@@ -3050,8 +3145,7 @@ impl CdpConnection {
             + shared_worker_running_worker_isolate_count;
         let estimated_live_v8_isolate_count =
             estimated_document_isolate_count + estimated_worker_isolate_count;
-        let active_navigation_engine_resource_runtime = self
-            .engine
+        let active_navigation_engine_resource_runtime = active_engine
             .resource_request_client()
             .map(|client| client.resource_runtime_diagnostics());
         let active_navigation_engine_resource_runtime_id =
@@ -3074,12 +3168,12 @@ impl CdpConnection {
                 "targetDiscoveryEnabled": self.target_discovery_enabled,
                 "targetInfoChangeEventsEnabled": self.target_info_change_events_enabled,
                 "activeNavigationEngine": {
-                    "imageFetchEnabled": self.engine.image_fetch_enabled(),
-                    "optionalResourceFetchMask": self.engine.optional_resource_fetch_mask().bits(),
-                    "subframeLoadingEnabled": self.engine.subframe_loading_enabled(),
+                    "imageFetchEnabled": active_engine.image_fetch_enabled(),
+                    "optionalResourceFetchMask": active_engine.optional_resource_fetch_mask().bits(),
+                    "subframeLoadingEnabled": active_engine.subframe_loading_enabled(),
                     "resourceRuntimeId": active_navigation_engine_resource_runtime_id,
                     "networkMemoryCache": active_navigation_engine_memory_cache,
-                    "browserContextRuntime": self.engine
+                    "browserContextRuntime": active_engine
                         .browser_context_runtime()
                         .moli_memory_diagnostics(),
                 },
@@ -3217,6 +3311,18 @@ impl CdpConnection {
         browser_context
     }
 
+    pub(crate) fn ensure_browser_context_for_implicit_target_creation(&mut self) {
+        if self.browser_context.is_some() || !self.inactive_browser_contexts.is_empty() {
+            return;
+        }
+        let browser_context_id = if self.default_target_lifecycle.is_placeholder() {
+            self.default_browser_context_id().to_owned()
+        } else {
+            self.gen_bc_id()
+        };
+        self.insert_browser_context(self.new_browser_context(browser_context_id));
+    }
+
     fn apply_global_browser_context_state(&self, browser_context: &mut BrowserContext) {
         browser_context
             .network_policy
@@ -3284,7 +3390,7 @@ impl CdpConnection {
     }
 
     pub fn default_browser_context_id(&self) -> &'static str {
-        "BID-default"
+        DEFAULT_BROWSER_CONTEXT_ID
     }
 
     pub fn default_target_id(&self) -> &'static str {
@@ -3293,6 +3399,112 @@ impl CdpConnection {
 
     pub fn default_tab_target_id(&self) -> &'static str {
         DEFAULT_CDP_TAB_TARGET_ID
+    }
+
+    pub(crate) fn devtools_target_info(&self, target_id: &str) -> Option<DevToolsTargetInfo> {
+        if let Some(page_target_id) = self.primary_page_target_id_for_tab_target_id(target_id) {
+            let page_target_info = self.devtools_page_or_worker_target_info(page_target_id)?;
+            return self
+                .target_control
+                .tab_target_info_for_page_target_info(page_target_info);
+        }
+        self.devtools_page_or_worker_target_info(target_id)
+    }
+
+    fn devtools_page_or_worker_target_info(&self, target_id: &str) -> Option<DevToolsTargetInfo> {
+        self.browser_contexts()
+            .find_map(|browser_context| browser_context.devtools_target_info(target_id))
+            .or_else(|| {
+                (target_id == DEFAULT_CDP_PAGE_TARGET_ID)
+                    .then(|| self.default_target_lifecycle.placeholder_page_info())
+                    .flatten()
+            })
+    }
+
+    pub(crate) fn devtools_target_infos(&self) -> Vec<DevToolsTargetInfo> {
+        let mut target_infos = Vec::new();
+        if let Some(page_target_info) = self.default_target_lifecycle.placeholder_page_info() {
+            if let Some(tab_target_info) = self
+                .target_control
+                .tab_target_info_for_page_target_info(page_target_info.clone())
+            {
+                target_infos.push(tab_target_info);
+            }
+            target_infos.push(page_target_info);
+        }
+        for browser_context in self.browser_contexts() {
+            for mut page_or_worker_target_info in browser_context.devtools_target_infos() {
+                if let Some(target_id) = page_or_worker_target_info.target_id.as_ref() {
+                    page_or_worker_target_info.moli_popup_id =
+                        browser_context.target_popup_id(target_id.as_str());
+                }
+                if let Some(tab_target_info) = self
+                    .target_control
+                    .tab_target_info_for_page_target_info(page_or_worker_target_info.clone())
+                {
+                    target_infos.push(tab_target_info);
+                }
+                target_infos.push(page_or_worker_target_info);
+            }
+        }
+        target_infos
+    }
+
+    pub fn publish_default_browser_target(&mut self) {
+        if !self.default_target_lifecycle.publish() {
+            return;
+        }
+        let default_target_id = self.default_target_id().to_owned();
+        self.register_top_level_page_target(&default_target_id);
+        self.notify_target_host_activated(&default_target_id);
+    }
+
+    /// Crosses the default target's placeholder-to-live boundary when the
+    /// requested operation genuinely needs a page owner.
+    pub(crate) fn ensure_default_target_live(&mut self, target_id: &str) {
+        if self
+            .default_target_lifecycle
+            .is_placeholder_target(target_id)
+        {
+            self.install_default_browser_target();
+        }
+    }
+
+    pub(crate) fn default_placeholder_is_logically_active(&self, target_id: &str) -> bool {
+        self.default_target_lifecycle
+            .is_placeholder_target(target_id)
+            && self.browser_contexts().all(|browser_context| {
+                !browser_context.has_active_target()
+                    && browser_context.background_targets.is_empty()
+            })
+    }
+
+    pub(crate) fn close_default_target_placeholder(
+        &mut self,
+        target_id: &str,
+    ) -> Option<TargetEventPlan> {
+        if !self
+            .default_target_lifecycle
+            .is_placeholder_target(target_id)
+        {
+            return None;
+        }
+
+        let target_host_closure = self.prepare_target_host_closure(DEFAULT_CDP_PAGE_TARGET_ID);
+        let (detached_info_deltas, destroyed_deltas) = target_host_closure.into_parts();
+        let mut plan = self.prepared_target_host_deltas_event_plan(detached_info_deltas);
+        plan.extend(self.detach_closed_top_level_target_sessions_event_plan(
+            DEFAULT_CDP_PAGE_TARGET_ID,
+            Some("Render process gone."),
+        ));
+        let closed = self.default_target_lifecycle.close_placeholder(target_id);
+        debug_assert!(closed, "validated default placeholder must close");
+        plan.extend(self.prepared_target_host_deltas_event_plan(destroyed_deltas));
+        Some(plan)
+    }
+
+    pub(crate) fn mark_default_browser_target_closed(&mut self) {
+        self.default_target_lifecycle.mark_closed();
     }
 
     pub(crate) fn register_top_level_page_target(&mut self, page_target_id: &str) -> String {
@@ -3439,11 +3651,8 @@ impl CdpConnection {
     }
 
     pub(crate) fn tab_target_info(&self, tab_target_id: &str) -> Option<DevToolsTargetInfo> {
-        let page_target_id = self.primary_page_target_id_for_tab_target_id(tab_target_id)?;
-        let page_target_info = self
-            .browser_contexts()
-            .find_map(|browser_context| browser_context.devtools_target_info(page_target_id))?;
-        self.tab_target_info_for_page_target_info(&page_target_info)
+        let target_info = self.devtools_target_info(tab_target_id)?;
+        (target_info.kind == DevToolsTargetKind::Tab).then_some(target_info)
     }
 
     pub(crate) fn set_target_discovery_for_owner(
@@ -3717,10 +3926,7 @@ impl CdpConnection {
     }
 
     fn target_info_for_host_delta(&self, target_id: &str) -> Option<DevToolsTargetInfo> {
-        self.tab_target_info(target_id).or_else(|| {
-            self.browser_contexts()
-                .find_map(|browser_context| browser_context.devtools_target_info(target_id))
-        })
+        self.devtools_target_info(target_id)
     }
 
     fn exact_target_info_changed_events_for_all_observer_owners(
@@ -3777,19 +3983,51 @@ impl CdpConnection {
     }
 
     pub fn install_default_browser_target(&mut self) {
-        if self.browser_context.is_some() || !self.inactive_browser_contexts.is_empty() {
+        if self.default_target_lifecycle.is_live() || self.default_target_lifecycle.is_closed() {
             return;
         }
 
-        let mut browser_context =
-            self.new_browser_context(self.default_browser_context_id().to_owned());
-        browser_context.set_active_target_id(self.default_target_id().to_owned());
-        browser_context.set_target_url("about:blank".to_owned());
-        browser_context.begin_active_target_initial_empty_document("about:blank".to_owned());
-        self.insert_browser_context(browser_context);
+        let was_placeholder = self.default_target_lifecycle.is_placeholder();
+        let default_browser_context_id = self.default_browser_context_id().to_owned();
         let default_target_id = self.default_target_id().to_owned();
-        self.register_top_level_page_target(&default_target_id);
-        self.notify_target_host_activated(&default_target_id);
+        if !self.has_browser_context_id(&default_browser_context_id) {
+            let mut browser_context = self.new_browser_context(default_browser_context_id.clone());
+            browser_context.set_active_target_id(default_target_id.clone());
+            browser_context.set_target_url("about:blank".to_owned());
+            browser_context.begin_active_target_initial_empty_document("about:blank".to_owned());
+            self.insert_browser_context(browser_context);
+        } else {
+            let browser_context = self
+                .browser_context_by_id_mut(&default_browser_context_id)
+                .expect("known default BrowserContext must remain addressable");
+            if !browser_context.is_active_target(&default_target_id)
+                && browser_context
+                    .background_target(&default_target_id)
+                    .is_none()
+            {
+                if browser_context.has_active_target() {
+                    browser_context.stage_background_target(
+                        default_target_id.clone(),
+                        None,
+                        "about:blank".to_owned(),
+                        Some("about:blank".to_owned()),
+                        None,
+                    );
+                } else {
+                    browser_context.set_active_target_id(default_target_id.clone());
+                    browser_context.set_target_url("about:blank".to_owned());
+                    browser_context
+                        .begin_active_target_initial_empty_document("about:blank".to_owned());
+                }
+            }
+        }
+        if self.target_control.host_kind(&default_target_id).is_none() {
+            self.register_top_level_page_target(&default_target_id);
+        }
+        self.default_target_lifecycle.mark_live();
+        if !was_placeholder {
+            self.notify_target_host_activated(&default_target_id);
+        }
     }
 
     pub fn enable_default_target_on_auto_attach(&mut self) {

--- a/moli-protocol/src/conn/activity_source.rs
+++ b/moli-protocol/src/conn/activity_source.rs
@@ -143,7 +143,7 @@ impl CdpConnection {
                 inactive_browser_contexts,
                 &route,
             )?;
-            return Some((engine, slot));
+            return Some((engine.ensure_mut(), slot));
         }
 
         let (browser_context_id, target_id) = match &route {

--- a/moli-protocol/src/conn/browser_context/lifecycle.rs
+++ b/moli-protocol/src/conn/browser_context/lifecycle.rs
@@ -184,7 +184,10 @@ impl CdpConnection {
         });
         if let Some((browser_context_id, target_id)) = current_active_engine_key {
             self.apply_scheduler_senders_to_navigation_engine(&next_engine);
-            let active_engine = self.engine.replace(next_engine);
+            let active_engine = self
+                .engine
+                .replace(next_engine)
+                .expect("active browser context must have a navigation engine");
             self.retain_background_navigation_engine(browser_context_id, target_id, active_engine)
                 .expect("inactive BrowserContext must retain its exact active-target engine");
         } else {

--- a/moli-protocol/src/conn/browser_context/target_session_owner.rs
+++ b/moli-protocol/src/conn/browser_context/target_session_owner.rs
@@ -2404,7 +2404,7 @@ impl CdpConnection {
             Some(TargetSessionOwnerRef::NoLoadedBrowserContext) | None => {
                 TargetNavigationLoadInputs::no_loaded_browser_context(
                     self.initial_storage_partition.page_storage_handles(),
-                    self.engine.browser_context_owner_access(),
+                    self.engine.ensure().browser_context_owner_access(),
                 )
             }
             Some(owner) => owner.navigation_load_inputs(),

--- a/moli-protocol/src/conn/resource_runtime_support.rs
+++ b/moli-protocol/src/conn/resource_runtime_support.rs
@@ -10,11 +10,16 @@ use super::{
 
 impl CdpConnection {
     pub(crate) fn invalidate_resource_runtime(&mut self) {
-        self.engine.reset_resource_runtime_without_loaded_page();
+        self.engine
+            .ensure_mut()
+            .reset_resource_runtime_without_loaded_page();
     }
 
     pub(crate) async fn invalidate_resource_runtime_async(&mut self) {
-        self.engine.reset_resource_runtime_async(None).await;
+        self.engine
+            .ensure_mut()
+            .reset_resource_runtime_async(None)
+            .await;
     }
 
     pub(crate) fn resource_storage_handles(&self) -> BrowserContextResourceStorageHandles {
@@ -30,9 +35,11 @@ impl CdpConnection {
         self.apply_active_engine_fetch_overrides();
         let storage = self.resource_storage_handles();
         self.engine
+            .ensure_mut()
             .ensure_resource_runtime_ready_for_navigation_storage(storage.into_navigation_storage())
             .map_err(|error| format!("failed to initialize resource runtime: {error}"))?;
         self.engine
+            .ensure()
             .resource_request_client()
             .ok_or_else(|| "resource request client unavailable".to_owned())
     }
@@ -63,9 +70,11 @@ impl CdpConnection {
         self.apply_navigation_load_input_engine_fetch_overrides(load_inputs);
         let storage = load_inputs.resource_storage_handles();
         self.engine
+            .ensure_mut()
             .ensure_resource_runtime_ready_for_navigation_storage(storage.into_navigation_storage())
             .map_err(|error| format!("failed to initialize resource runtime: {error}"))?;
         self.engine
+            .ensure()
             .resource_request_client()
             .ok_or_else(|| "resource request client unavailable".to_owned())
     }
@@ -77,6 +86,7 @@ impl CdpConnection {
         let Some(browser_context_id) = load_inputs.browser_context_id.as_deref() else {
             return self
                 .engine
+                .ensure()
                 .browser_context_runtime()
                 .shares_state_with(&load_inputs.renderer_runtime.runtime());
         };
@@ -85,6 +95,7 @@ impl CdpConnection {
                 && context.active_target_id() == load_inputs.root_frame_id.as_deref()
                 && self
                     .engine
+                    .ensure()
                     .browser_context_runtime()
                     .shares_state_with(&load_inputs.renderer_runtime.runtime())
         })
@@ -110,12 +121,12 @@ impl CdpConnection {
         let tls_verify_host = load_inputs
             .tls_verify_host_override
             .unwrap_or(self.base_tls_verify_host);
-        self.engine.set_browser_identity_override(browser_identity);
-        self.engine.set_http_proxy_override(http_proxy);
-        self.engine.set_http_no_proxy_override(http_no_proxy);
-        self.engine.set_tls_verify_host(tls_verify_host);
-        self.engine
-            .set_bypass_service_worker(load_inputs.bypass_service_worker);
+        let engine = self.engine.ensure_mut();
+        engine.set_browser_identity_override(browser_identity);
+        engine.set_http_proxy_override(http_proxy);
+        engine.set_http_no_proxy_override(http_no_proxy);
+        engine.set_tls_verify_host(tls_verify_host);
+        engine.set_bypass_service_worker(load_inputs.bypass_service_worker);
     }
 
     pub(crate) fn build_registered_browser_resource_runtime_for_navigation_load_inputs(
@@ -163,6 +174,7 @@ impl CdpConnection {
         self.apply_active_engine_fetch_overrides();
         let storage = self.resource_storage_handles();
         self.engine
+            .ensure_mut()
             .ensure_cookie_store_for_navigation_storage(storage.into_navigation_storage())
             .map_err(|error| format!("failed to initialize loader: {error}"))
     }
@@ -173,7 +185,10 @@ impl CdpConnection {
             .browser_context
             .as_mut()
             .and_then(|bc| bc.active_target.runtime_slot.loaded_page_mut());
-        self.engine.reset_resource_runtime_async(page).await;
+        self.engine
+            .ensure_mut()
+            .reset_resource_runtime_async(page)
+            .await;
     }
 
     pub(crate) async fn rebuild_resource_runtime_for_loaded_page_async(&mut self) {
@@ -184,6 +199,7 @@ impl CdpConnection {
                 .as_mut()
                 .and_then(|bc| bc.active_target.runtime_slot.loaded_page_mut());
             self.engine
+                .ensure_mut()
                 .rebuild_resource_runtime_for_page_with_storage_async(
                     storage.into_navigation_storage(),
                     page,
@@ -195,7 +211,10 @@ impl CdpConnection {
                 .browser_context
                 .as_mut()
                 .and_then(|bc| bc.active_target.runtime_slot.loaded_page_mut());
-            self.engine.reset_resource_runtime_async(page).await;
+            self.engine
+                .ensure_mut()
+                .reset_resource_runtime_async(page)
+                .await;
         }
     }
 
@@ -208,6 +227,7 @@ impl CdpConnection {
         let request_client = if self.navigation_load_inputs_use_primary_engine(&load_inputs) {
             self.apply_navigation_load_input_engine_fetch_overrides(&load_inputs);
             self.engine
+                .ensure_mut()
                 .rebuild_resource_request_client_for_navigation_storage(
                     storage.into_navigation_storage(),
                 )

--- a/moli-protocol/src/conn/runtime_load.rs
+++ b/moli-protocol/src/conn/runtime_load.rs
@@ -2271,7 +2271,7 @@ impl CdpConnection {
         body_progress_source: MainDocumentBodyProgressSource,
     ) -> Result<NavigationLoadOutcome, String> {
         if load_inputs.browser_context_id.is_none() {
-            let page_reservation = self.engine.reserve_page_for_creation();
+            let page_reservation = self.engine.ensure().reserve_page_for_creation();
             if let Some(navigation) = self
                 .load_inline_html_navigation_async(
                     page_reservation,
@@ -2285,7 +2285,7 @@ impl CdpConnection {
                 return navigation;
             }
             if let Some(navigation) = load_data_url_navigation_with_engine_async(
-                &mut self.engine,
+                self.engine.ensure_mut(),
                 page_reservation,
                 &load_inputs,
                 method,
@@ -2516,12 +2516,13 @@ impl CdpConnection {
         // renderer owners.
         let mut engine = if self
             .engine
+            .ensure()
             .browser_context_runtime()
             .shares_state_with(&load_inputs.renderer_runtime.runtime())
         {
             NavigationEngine::new_with_runtime_config_and_shared_renderer_owner(
                 self.navigation_runtime_config_for_load_inputs(load_inputs),
-                &self.engine,
+                self.engine.ensure(),
             )
             .expect("active shared BrowserContext owner must be live")
         } else if let Some(engine) = self
@@ -2612,11 +2613,13 @@ impl CdpConnection {
         }
         let resource_storage = load_inputs.resource_storage_handles();
         self.engine
+            .ensure_mut()
             .ensure_resource_runtime_ready_for_navigation_storage(
                 resource_storage.into_navigation_storage(),
             )
             .ok()?;
         self.engine
+            .ensure()
             .resource_request_client()
             .map(|client| client.browser_resource_runtime())
     }
@@ -2627,6 +2630,7 @@ impl CdpConnection {
     ) -> bool {
         if !self
             .engine
+            .ensure()
             .browser_context_runtime()
             .shares_state_with(&load_inputs.renderer_runtime.runtime())
         {
@@ -2688,7 +2692,7 @@ impl CdpConnection {
         request_headers: Vec<(String, String)>,
     ) -> Option<Result<NavigationLoadOutcome, String>> {
         load_inline_html_navigation_with_engine_async(
-            &mut self.engine,
+            self.engine.ensure_mut(),
             page_reservation,
             load_inputs,
             method,
@@ -2896,14 +2900,14 @@ impl CdpConnection {
             from_cache: false,
             negotiated_http_version: None,
         };
-        let page_reservation = self.engine.reserve_page_for_creation();
+        let page_reservation = self.engine.ensure().reserve_page_for_creation();
         self.bind_renderer_page_reservation_for_session_owner(
             session_id,
             load_inputs,
             page_reservation,
         );
         prepare_navigation_from_captured_raw_response_with_engine_async(
-            &mut self.engine,
+            self.engine.ensure_mut(),
             page_reservation,
             load_inputs,
             requested_url,
@@ -2943,6 +2947,7 @@ impl CdpConnection {
             .map(Arc::new);
         let built = self
             .engine
+            .ensure_mut()
             .build_html_page_from_response_with_storage_and_inspector_session_restores_async(
                 page_storage.into_navigation_storage(),
                 requested_url.clone(),
@@ -3042,8 +3047,10 @@ impl CdpConnection {
         }
         let resource_storage = load_inputs.resource_storage_handles();
         self.engine
+            .ensure_mut()
             .set_bypass_service_worker(load_inputs.bypass_service_worker);
         self.engine
+            .ensure_mut()
             .fetch_navigation_response_with_storage_async(
                 resource_storage.into_navigation_storage(),
                 load_inputs.navigation_initiator_url.as_ref(),
@@ -3232,6 +3239,7 @@ impl CdpConnection {
             .map(Arc::new);
         let built = self
             .engine
+            .ensure_mut()
             .build_html_page_from_response_with_storage_and_inspector_session_restores_async(
                 page_storage.into_navigation_storage(),
                 requested_url.clone(),
@@ -3464,14 +3472,14 @@ impl CdpConnection {
             ));
         }
 
-        let page_reservation = self.engine.reserve_page_for_creation();
+        let page_reservation = self.engine.ensure().reserve_page_for_creation();
         self.bind_renderer_page_reservation_for_session_owner(
             session_id,
             load_inputs,
             page_reservation,
         );
         prepare_navigation_from_captured_raw_response_with_engine_async(
-            &mut self.engine,
+            self.engine.ensure_mut(),
             page_reservation,
             load_inputs,
             requested_url,
@@ -3592,9 +3600,9 @@ impl CdpConnection {
         let (response, network_observation_journal) =
             response.into_parts_with_observation_journal();
         if load_inputs.browser_context_id.is_none() {
-            let page_reservation = self.engine.reserve_page_for_creation();
+            let page_reservation = self.engine.ensure().reserve_page_for_creation();
             return build_navigation_from_streaming_raw_response_with_engine_async(
-                &mut self.engine,
+                self.engine.ensure_mut(),
                 page_reservation,
                 load_inputs,
                 requested_url,

--- a/moli-protocol/src/conn/settings/engine.rs
+++ b/moli-protocol/src/conn/settings/engine.rs
@@ -28,11 +28,12 @@ impl CdpConnection {
             .browser_context
             .as_ref()
             .is_some_and(|bc| bc.network_policy.bypass_service_worker());
-        self.engine.set_browser_identity_override(browser_identity);
-        self.engine.set_http_proxy_override(http_proxy);
-        self.engine.set_http_no_proxy_override(http_no_proxy);
-        self.engine.set_tls_verify_host(tls_verify_host);
-        self.engine.set_bypass_service_worker(bypass_service_worker);
+        let engine = self.engine.ensure_mut();
+        engine.set_browser_identity_override(browser_identity);
+        engine.set_http_proxy_override(http_proxy);
+        engine.set_http_no_proxy_override(http_no_proxy);
+        engine.set_tls_verify_host(tls_verify_host);
+        engine.set_bypass_service_worker(bypass_service_worker);
     }
 
     pub async fn set_tls_verify_host_async(&mut self, enabled: bool) {

--- a/moli-protocol/src/conn/target/activation.rs
+++ b/moli-protocol/src/conn/target/activation.rs
@@ -116,7 +116,10 @@ impl CdpConnection {
                 .expect("active BrowserContext owner must be live")
             });
             self.apply_scheduler_senders_to_navigation_engine(&next_engine);
-            let active_engine = self.engine.replace(next_engine);
+            let active_engine = self
+                .engine
+                .replace(next_engine)
+                .expect("active target must have a navigation engine");
             self.retain_background_navigation_engine(
                 browser_context_id,
                 active_target_id,
@@ -147,7 +150,10 @@ impl CdpConnection {
         )
         .expect("active BrowserContext owner must be live");
         self.apply_scheduler_senders_to_navigation_engine(&next_engine);
-        let active_engine = self.engine.replace(next_engine);
+        let active_engine = self
+            .engine
+            .replace(next_engine)
+            .expect("active target must have a navigation engine");
         self.retain_background_navigation_engine(
             browser_context_id,
             active_target_id,

--- a/moli-protocol/src/conn/target/default_target.rs
+++ b/moli-protocol/src/conn/target/default_target.rs
@@ -1,0 +1,128 @@
+use crate::devtools_runtime::{
+    DevToolsBrowserContextId, DevToolsTargetId, DevToolsTargetInfo, DevToolsTargetKind,
+};
+
+use crate::{DEFAULT_CDP_PAGE_TARGET_ID, DEFAULT_CDP_TAB_TARGET_ID};
+
+pub(crate) const DEFAULT_BROWSER_CONTEXT_ID: &str = "BID-default";
+
+/// Lifecycle of the server-published default target.
+///
+/// A placeholder is a real target-catalog entry, but it deliberately owns no
+/// `BrowserContext` or navigation runtime until an operation needs a live page.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) enum DefaultTargetLifecycle {
+    #[default]
+    Unpublished,
+    Placeholder,
+    Live,
+    Closed,
+}
+
+impl DefaultTargetLifecycle {
+    pub(crate) fn publish(&mut self) -> bool {
+        if *self != Self::Unpublished {
+            return false;
+        }
+        *self = Self::Placeholder;
+        true
+    }
+
+    pub(crate) fn is_placeholder(&self) -> bool {
+        *self == Self::Placeholder
+    }
+
+    pub(crate) fn is_live(&self) -> bool {
+        *self == Self::Live
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        *self == Self::Closed
+    }
+
+    pub(crate) fn owns(target_id: &str) -> bool {
+        matches!(
+            target_id,
+            DEFAULT_CDP_PAGE_TARGET_ID | DEFAULT_CDP_TAB_TARGET_ID
+        )
+    }
+
+    pub(crate) fn is_placeholder_target(&self, target_id: &str) -> bool {
+        self.is_placeholder() && Self::owns(target_id)
+    }
+
+    pub(crate) fn placeholder_page_info(&self) -> Option<DevToolsTargetInfo> {
+        self.is_placeholder().then(|| DevToolsTargetInfo {
+            target_id: Some(DevToolsTargetId::from(DEFAULT_CDP_PAGE_TARGET_ID)),
+            kind: DevToolsTargetKind::Page,
+            title: String::new(),
+            url: "about:blank".to_owned(),
+            attached: false,
+            opener_id: None,
+            opener_frame_id: None,
+            can_access_opener: false,
+            browser_context_id: Some(DevToolsBrowserContextId::from(DEFAULT_BROWSER_CONTEXT_ID)),
+            moli_popup_id: None,
+        })
+    }
+
+    pub(crate) fn mark_live(&mut self) {
+        if *self != Self::Closed {
+            *self = Self::Live;
+        }
+    }
+
+    pub(crate) fn close_placeholder(&mut self, target_id: &str) -> bool {
+        if !self.is_placeholder_target(target_id) {
+            return false;
+        }
+        *self = Self::Closed;
+        true
+    }
+
+    pub(crate) fn mark_closed(&mut self) {
+        *self = Self::Closed;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_BROWSER_CONTEXT_ID, DefaultTargetLifecycle};
+    use crate::{DEFAULT_CDP_PAGE_TARGET_ID, DEFAULT_CDP_TAB_TARGET_ID};
+
+    #[test]
+    fn lifecycle_only_exposes_placeholder_metadata_while_published() {
+        let mut lifecycle = DefaultTargetLifecycle::default();
+        assert!(lifecycle.placeholder_page_info().is_none());
+        assert!(lifecycle.publish());
+        assert!(!lifecycle.publish());
+
+        let info = lifecycle
+            .placeholder_page_info()
+            .expect("published placeholder info");
+        assert_eq!(
+            info.target_id.as_ref().map(|id| id.as_str()),
+            Some(DEFAULT_CDP_PAGE_TARGET_ID)
+        );
+        assert_eq!(
+            info.browser_context_id.as_ref().map(|id| id.as_str()),
+            Some(DEFAULT_BROWSER_CONTEXT_ID)
+        );
+        assert!(lifecycle.is_placeholder_target(DEFAULT_CDP_TAB_TARGET_ID));
+
+        lifecycle.mark_live();
+        assert!(lifecycle.is_live());
+        assert!(lifecycle.placeholder_page_info().is_none());
+    }
+
+    #[test]
+    fn closed_default_target_cannot_be_republished_or_revived() {
+        let mut lifecycle = DefaultTargetLifecycle::default();
+        assert!(lifecycle.publish());
+        assert!(lifecycle.close_placeholder(DEFAULT_CDP_PAGE_TARGET_ID));
+        assert!(!lifecycle.publish());
+        lifecycle.mark_live();
+        assert!(!lifecycle.is_live());
+        assert!(lifecycle.placeholder_page_info().is_none());
+    }
+}

--- a/moli-protocol/src/conn/target/mod.rs
+++ b/moli-protocol/src/conn/target/mod.rs
@@ -1,6 +1,7 @@
 mod activation;
 mod auto_attach_owner;
 mod control;
+mod default_target;
 mod graph;
 mod host;
 mod observer;
@@ -15,6 +16,7 @@ mod worker_session;
 
 pub(crate) use activation::TargetActivationTransition;
 pub(crate) use control::TargetControlPlane;
+pub(crate) use default_target::{DEFAULT_BROWSER_CONTEXT_ID, DefaultTargetLifecycle};
 pub(crate) use observer::{TargetHandlerStore, target_destroyed_automation_events};
 pub(crate) use registry::{TargetClosurePlan, TargetHostDelta, TargetRegistry};
 pub(crate) use route::{CdpSessionRoute, TargetHandlerAccessMode};

--- a/moli-protocol/src/conn/tests/mod.rs
+++ b/moli-protocol/src/conn/tests/mod.rs
@@ -49,6 +49,157 @@ mod resource_runtime;
 mod site_data;
 
 #[test]
+fn published_default_target_defers_navigation_runtime_until_materialization() {
+    let mut conn = CdpConnection::new_with_deferred_navigation_runtime(
+        crate::CdpInitialStoragePartition::memory(),
+        NavigationRuntimeConfig::default(),
+    );
+
+    assert!(!conn.engine.is_materialized());
+    let (renderer_publication_sender, _renderer_publication_receiver) =
+        moli_core::renderer_output_transport_channel();
+    conn.set_renderer_publication_sender(renderer_publication_sender);
+    conn.publish_default_browser_target();
+
+    assert!(!conn.engine.is_materialized());
+    let page = conn
+        .devtools_target_info(conn.default_target_id())
+        .expect("published default page target");
+    let tab = conn
+        .devtools_target_info(conn.default_tab_target_id())
+        .expect("published default tab target");
+    assert_eq!(page.url, "about:blank");
+    assert_eq!(tab.url, "about:blank");
+
+    conn.install_default_browser_target();
+
+    assert!(conn.engine.is_materialized());
+    assert!(
+        conn.devtools_target_info(conn.default_target_id())
+            .is_some()
+    );
+    assert_eq!(
+        conn.browser_context
+            .as_ref()
+            .and_then(BrowserContext::active_target_id),
+        Some(conn.default_target_id())
+    );
+}
+
+fn deferred_default_connection() -> CdpConnection {
+    let mut conn = CdpConnection::new_with_deferred_navigation_runtime(
+        crate::CdpInitialStoragePartition::memory(),
+        NavigationRuntimeConfig::default(),
+    );
+    conn.publish_default_browser_target();
+    conn
+}
+
+#[tokio::test]
+async fn activating_the_only_default_placeholder_does_not_start_the_runtime() {
+    let mut conn = deferred_default_connection();
+    let target_id = conn.default_target_id();
+    let raw = json!({
+        "id": 1,
+        "method": "Target.activateTarget",
+        "params": { "targetId": target_id },
+    })
+    .to_string();
+
+    let messages = conn.process_message_messages_only_for_test(&raw).await;
+
+    assert_eq!(messages, vec![json!({ "id": 1, "result": {} })]);
+    assert!(!conn.engine.is_materialized());
+    assert!(conn.devtools_target_info(target_id).is_some());
+}
+
+#[tokio::test]
+async fn closing_the_default_placeholder_does_not_start_the_runtime() {
+    let mut conn = deferred_default_connection();
+    let raw = json!({
+        "id": 2,
+        "method": "Target.closeTarget",
+        "params": { "targetId": conn.default_tab_target_id() },
+    })
+    .to_string();
+
+    let messages = conn.process_message_messages_only_for_test(&raw).await;
+
+    assert_eq!(
+        messages.first(),
+        Some(&json!({ "id": 2, "result": { "success": true } }))
+    );
+    assert!(!conn.engine.is_materialized());
+    assert!(
+        conn.devtools_target_info(conn.default_target_id())
+            .is_none()
+    );
+    assert!(
+        conn.target_registry_host_kind(conn.default_target_id())
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn creating_a_target_preserves_the_published_default_as_a_placeholder() {
+    let mut conn = deferred_default_connection();
+    let raw = json!({
+        "id": 3,
+        "method": "Target.createTarget",
+        "params": { "url": "about:blank" },
+    })
+    .to_string();
+
+    let messages = conn.process_message_messages_only_for_test(&raw).await;
+    let created_target_id = messages
+        .iter()
+        .find(|message| message["id"] == json!(3))
+        .and_then(|message| message["result"]["targetId"].as_str())
+        .expect("createTarget response");
+
+    assert_ne!(created_target_id, conn.default_target_id());
+    assert!(conn.engine.is_materialized());
+    assert!(conn.default_target_lifecycle.is_placeholder());
+    assert!(
+        conn.devtools_target_info(conn.default_target_id())
+            .is_some()
+    );
+    assert_eq!(
+        conn.browser_context
+            .as_ref()
+            .map(|context| context.id.as_str()),
+        Some(conn.default_browser_context_id())
+    );
+
+    let attach_raw = json!({
+        "id": 4,
+        "method": "Target.attachToTarget",
+        "params": { "targetId": conn.default_target_id(), "flatten": true },
+    })
+    .to_string();
+    let attach_messages = conn
+        .process_message_messages_only_for_test(&attach_raw)
+        .await;
+
+    assert!(attach_messages.iter().any(|message| {
+        message["id"] == json!(4) && message["result"]["sessionId"].is_string()
+    }));
+    assert!(conn.default_target_lifecycle.is_live());
+    let browser_context = conn.browser_context.as_ref().expect("default context");
+    assert_eq!(
+        browser_context.active_target_id(),
+        Some(created_target_id),
+        "attaching the placeholder must not activate it"
+    );
+    assert!(
+        browser_context
+            .background_target(conn.default_target_id())
+            .is_some(),
+        "first live use should materialize the default behind the catalog entry"
+    );
+}
+
+#[test]
 fn idle_navigation_engine_reset_preserves_mock_layout_policy() {
     let mut conn = CdpConnection::new_with_initial_storage_partition_and_runtime_config(
         crate::CdpInitialStoragePartition::memory(),
@@ -364,6 +515,7 @@ fn active_browser_context_installs_its_renderer_runtime_on_engine() {
 
     assert!(
         conn.engine
+            .ensure()
             .browser_context_runtime()
             .shares_state_with(&renderer_runtime)
     );
@@ -382,6 +534,7 @@ fn activating_inactive_browser_context_switches_engine_renderer_runtime() {
 
     assert!(
         conn.engine
+            .ensure()
             .browser_context_runtime()
             .shares_state_with(&second_renderer_runtime)
     );
@@ -408,6 +561,7 @@ async fn removing_active_browser_context_switches_engine_to_promoted_context() {
     );
     assert!(
         conn.engine
+            .ensure()
             .browser_context_runtime()
             .shares_state_with(&second_renderer_runtime)
     );
@@ -662,12 +816,12 @@ async fn memory_diagnostics_ignores_empty_retained_renderer_owner_for_document_i
     let retained = NavigationEngine::new_with_fetch_config_and_browser_context_access(
         FetchConfig::default(),
         retained_context.renderer_runtime_owner_access(),
-        conn.engine.optional_resource_fetch_mask(),
-        conn.engine.subframe_loading_enabled(),
+        conn.engine.ensure().optional_resource_fetch_mask(),
+        conn.engine.ensure().subframe_loading_enabled(),
     )
     .expect("retained diagnostics context owner should be live");
     assert!(
-        !retained.shares_renderer_owner_with(&conn.engine),
+        !retained.shares_renderer_owner_with(conn.engine.ensure()),
         "test setup must retain a distinct renderer owner without a loaded document"
     );
     conn.inactive_browser_contexts.push(retained_context);
@@ -856,8 +1010,8 @@ fn memory_diagnostics_counts_shared_retained_background_engine_by_renderer_owner
     let active = NavigationEngine::new_with_fetch_config_and_browser_context_access(
         FetchConfig::default(),
         browser_context.renderer_runtime_owner_access(),
-        conn.engine.optional_resource_fetch_mask(),
-        conn.engine.subframe_loading_enabled(),
+        conn.engine.ensure().optional_resource_fetch_mask(),
+        conn.engine.ensure().subframe_loading_enabled(),
     )
     .expect("active diagnostics context owner should be live");
     conn.replace_navigation_engine(active);
@@ -865,13 +1019,13 @@ fn memory_diagnostics_counts_shared_retained_background_engine_by_renderer_owner
 
     let retained = NavigationEngine::new_with_fetch_config_and_shared_renderer_owner(
         FetchConfig::default(),
-        &conn.engine,
-        conn.engine.optional_resource_fetch_mask(),
-        conn.engine.subframe_loading_enabled(),
+        conn.engine.ensure(),
+        conn.engine.ensure().optional_resource_fetch_mask(),
+        conn.engine.ensure().subframe_loading_enabled(),
     )
     .expect("retained diagnostics wrapper should share a live context owner");
     assert!(
-        retained.shares_renderer_owner_with(&conn.engine),
+        retained.shares_renderer_owner_with(conn.engine.ensure()),
         "test setup must retain a NavigationEngine wrapper that shares the active renderer owner"
     );
     conn.retain_background_navigation_engine(
@@ -907,8 +1061,8 @@ fn retained_background_engine_rejects_a_foreign_browser_context_route() {
     let foreign_engine = NavigationEngine::new_with_fetch_config_and_browser_context_access(
         FetchConfig::default(),
         foreign_context.renderer_runtime_owner_access(),
-        conn.engine.optional_resource_fetch_mask(),
-        conn.engine.subframe_loading_enabled(),
+        conn.engine.ensure().optional_resource_fetch_mask(),
+        conn.engine.ensure().subframe_loading_enabled(),
     )
     .expect("foreign context owner should be live during the regression");
 

--- a/moli-protocol/src/domains/target/activation.rs
+++ b/moli-protocol/src/domains/target/activation.rs
@@ -59,6 +59,10 @@ pub(super) async fn execute_devtools_activate_target_command_async(
     conn: &mut CdpConnection,
     command: DevToolsActivateTargetCommand,
 ) -> Result<Vec<BackgroundProtocolEvent>, DevToolsError> {
+    if conn.default_placeholder_is_logically_active(command.target_id.as_str()) {
+        return Ok(Vec::new());
+    }
+    conn.ensure_default_target_live(command.target_id.as_str());
     let target_id = conn
         .primary_page_target_id_for_tab_target_id(command.target_id.as_str())
         .map(str::to_owned)

--- a/moli-protocol/src/domains/target/attachment.rs
+++ b/moli-protocol/src/domains/target/attachment.rs
@@ -135,6 +135,7 @@ fn do_attach(conn: &mut CdpConnection, cmd: &Cmd<'_>, target_id: &str) -> Target
         // AttachToBrowserTarget action, not to generic attachment of a known host.
         return TargetCommandTaskStep::Complete(attach_browser_target(conn, cmd.session_id));
     }
+    conn.ensure_default_target_live(target_id);
     let attach_from_browser_session = conn.is_browser_session_id(cmd.session_id);
     if conn
         .primary_page_target_id_for_tab_target_id(target_id)

--- a/moli-protocol/src/domains/target/browser_context.rs
+++ b/moli-protocol/src/domains/target/browser_context.rs
@@ -408,27 +408,15 @@ fn devtools_target_infos(
     filter: Option<&[DevToolsTargetFilterEntry]>,
 ) -> Result<Vec<DevToolsTargetInfo>, DevToolsError> {
     let mut targets = Vec::new();
-    for browser_context in conn.browser_contexts() {
-        for mut target_info in browser_context.devtools_target_infos() {
-            if let Some(message) =
-                super::transient_no_page_devtools_target_info_error(conn, &target_info)
-            {
-                return Err(DevToolsError::new(DevToolsErrorKind::Internal, message));
-            }
-            if let Some(target_id) = target_info.target_id.as_ref() {
-                target_info.moli_popup_id = browser_context.target_popup_id(target_id.as_str());
-            }
-            if let Some(tab_target_info) = conn.tab_target_info_for_page_target_info(&target_info)
-                && target_info_matches_root(&tab_target_info, root)
-                && target_filter_allows_info(filter, &tab_target_info)
-            {
-                targets.push(tab_target_info);
-            }
-            if !target_info_matches_root(&target_info, root)
-                || !target_filter_allows_info(filter, &target_info)
-            {
-                continue;
-            }
+    for target_info in conn.devtools_target_infos() {
+        if let Some(message) =
+            super::transient_no_page_devtools_target_info_error(conn, &target_info)
+        {
+            return Err(DevToolsError::new(DevToolsErrorKind::Internal, message));
+        }
+        if target_info_matches_root(&target_info, root)
+            && target_filter_allows_info(filter, &target_info)
+        {
             targets.push(target_info);
         }
     }

--- a/moli-protocol/src/domains/target/closing.rs
+++ b/moli-protocol/src/domains/target/closing.rs
@@ -80,9 +80,20 @@ pub(super) async fn execute_devtools_close_target_command_async(
     out: &mut events::TargetProtocolSideEffects,
     command_context: &mut crate::conn::CommandDispatchContext,
 ) -> Result<DevToolsCloseTargetResult, DevToolsError> {
+    let closes_default_target = matches!(
+        command.target_id.as_str(),
+        crate::DEFAULT_CDP_PAGE_TARGET_ID | crate::DEFAULT_CDP_TAB_TARGET_ID
+    );
     let target_id = command.target_id.into_string();
+    if let Some(plan) = conn.close_default_target_placeholder(&target_id) {
+        out.extend_background_events(plan.into_background_events());
+        return Ok(DevToolsCloseTargetResult { success: true });
+    }
     let restore_browser_context_id = previously_active_browser_context_id(conn);
     let result = close_target_inner_async(conn, out, command_context, target_id).await;
+    if result.is_ok() && closes_default_target {
+        conn.mark_default_browser_target_closed();
+    }
     restore_previously_active_browser_context(conn, restore_browser_context_id.as_deref());
     result
 }

--- a/moli-protocol/src/domains/target/creation.rs
+++ b/moli-protocol/src/domains/target/creation.rs
@@ -281,10 +281,7 @@ pub(super) fn execute_devtools_create_target_command(
         restore_previously_active_browser_context(conn, restore_browser_context_id.as_deref());
         return Err(error);
     }
-    if conn.browser_context.is_none() && conn.inactive_browser_contexts.is_empty() {
-        let id = conn.gen_bc_id();
-        conn.insert_browser_context(conn.new_browser_context(id));
-    }
+    conn.ensure_browser_context_for_implicit_target_creation();
 
     let target_id = conn.gen_target_id();
     let default_target_id = conn.default_target_id();

--- a/moli-protocol/src/domains/target/info.rs
+++ b/moli-protocol/src/domains/target/info.rs
@@ -92,6 +92,14 @@ pub(super) fn execute_devtools_get_target_info_command(
             target_info: super::browser_context::devtools_browser_target_info(),
         });
     }
+    if let Some(target_info) = conn.devtools_target_info(wanted) {
+        if let Some(message) =
+            super::transient_no_page_devtools_target_info_error(conn, &target_info)
+        {
+            return Err(DevToolsError::new(DevToolsErrorKind::Internal, message));
+        }
+        return Ok(DevToolsGetTargetInfoResult { target_info });
+    }
     if conn.browser_context.is_none() && conn.inactive_browser_contexts.is_empty() {
         return Err(DevToolsError::new(
             DevToolsErrorKind::NoSuchTarget,
@@ -111,16 +119,8 @@ pub(super) fn execute_devtools_get_target_info_command(
             "TargetNotLoaded",
         ));
     }
-    let target_info = conn.tab_target_info(wanted);
-    if let Some(target_info) = target_info {
-        return Ok(DevToolsGetTargetInfoResult { target_info });
-    }
-    let target_info = conn
-        .browser_contexts()
-        .find_map(|browser_context| browser_context.devtools_target_info(wanted))
-        .ok_or_else(|| DevToolsError::new(DevToolsErrorKind::NoSuchTarget, "UnknownTargetId"))?;
-    if let Some(message) = super::transient_no_page_devtools_target_info_error(conn, &target_info) {
-        return Err(DevToolsError::new(DevToolsErrorKind::Internal, message));
-    }
-    Ok(DevToolsGetTargetInfoResult { target_info })
+    Err(DevToolsError::new(
+        DevToolsErrorKind::NoSuchTarget,
+        "UnknownTargetId",
+    ))
 }


### PR DESCRIPTION
Represent the published default page as a target-catalog placeholder with an explicit lifecycle. Materialize it only when an operation needs a live page owner; activate and close the placeholder directly, and create new targets without first constructing the default page.\n\nMake NavigationEngine initialization explicit so read-looking access cannot silently allocate the deferred runtime.