### PR TITLE
perf(queue): compact owner-ready task storage

### DIFF
--- a/moli-owner-queue/src/lib.rs
+++ b/moli-owner-queue/src/lib.rs
@@ -9,7 +9,7 @@ mod owner_task_source;
 mod owner_wake_queue;
 
 pub use owner_ready_task_source::{
-    OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal,
+    OwnerReadyTaskRoute, OwnerReadyTaskRouteClosed, OwnerReadyTaskSource, OwnerTaskReadySignal,
 };
 pub use owner_task_source::OwnerTaskSource;
 pub use owner_wake_queue::OwnerWakeQueue;

--- a/moli-owner-queue/src/owner_ready_task_source.rs
+++ b/moli-owner-queue/src/owner_ready_task_source.rs
@@ -1,12 +1,28 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::{collections::VecDeque, fmt, sync::Arc};
 
 use parking_lot::{Mutex, MutexGuard};
 
-use crate::OwnerTaskSource;
-
-#[derive(Debug, Default)]
-struct OwnerTaskReadinessState {
+#[derive(Debug)]
+struct OwnerReadyTaskState<T> {
+    incoming: VecDeque<T>,
     ready: bool,
+    source_open: bool,
+}
+
+impl<T> Default for OwnerReadyTaskState<T> {
+    fn default() -> Self {
+        Self {
+            incoming: VecDeque::new(),
+            ready: false,
+            source_open: true,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct OwnerReadyTaskShared<T, S> {
+    state: Mutex<OwnerReadyTaskState<T>>,
+    signal: S,
 }
 
 /// Fixed notification capability for one owner-ready task source.
@@ -19,6 +35,18 @@ pub trait OwnerTaskReadySignal: Send + Sync + 'static {
     fn signal_ready(&self);
 }
 
+/// Send error returned when an owner-ready source has already closed.
+#[derive(Debug, Eq, PartialEq)]
+pub struct OwnerReadyTaskRouteClosed<T>(pub T);
+
+impl<T> fmt::Display for OwnerReadyTaskRouteClosed<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("owner-ready task source is closed")
+    }
+}
+
+impl<T: fmt::Debug> std::error::Error for OwnerReadyTaskRouteClosed<T> {}
+
 /// Cloneable producer route for an owner task source with edge-triggered wakeups.
 ///
 /// The payload enqueue and the empty-to-nonempty wake are serialized with the
@@ -27,17 +55,13 @@ pub trait OwnerTaskReadySignal: Send + Sync + 'static {
 /// publish the wake.
 #[derive(Debug)]
 pub struct OwnerReadyTaskRoute<T, S> {
-    sender: tokio::sync::mpsc::UnboundedSender<T>,
-    readiness: Arc<Mutex<OwnerTaskReadinessState>>,
-    signal: Arc<S>,
+    shared: Arc<OwnerReadyTaskShared<T, S>>,
 }
 
 impl<T, S> Clone for OwnerReadyTaskRoute<T, S> {
     fn clone(&self) -> Self {
         Self {
-            sender: self.sender.clone(),
-            readiness: self.readiness.clone(),
-            signal: self.signal.clone(),
+            shared: self.shared.clone(),
         }
     }
 }
@@ -47,12 +71,15 @@ impl<T, S: OwnerTaskReadySignal> OwnerReadyTaskRoute<T, S> {
     pub fn send_and_signal_if_newly_ready(
         &self,
         task: T,
-    ) -> Result<(), tokio::sync::mpsc::error::SendError<T>> {
-        let mut readiness = lock_readiness(&self.readiness);
-        self.sender.send(task)?;
-        if !readiness.ready {
-            readiness.ready = true;
-            self.signal.signal_ready();
+    ) -> Result<(), OwnerReadyTaskRouteClosed<T>> {
+        let mut state = lock_state(&self.shared.state);
+        if !state.source_open {
+            return Err(OwnerReadyTaskRouteClosed(task));
+        }
+        state.incoming.push_back(task);
+        if !state.ready {
+            state.ready = true;
+            self.shared.signal.signal_ready();
         }
         Ok(())
     }
@@ -65,39 +92,38 @@ impl<T, S: OwnerTaskReadySignal> OwnerReadyTaskRoute<T, S> {
     pub fn send_all_and_signal_if_newly_ready(
         &self,
         tasks: impl IntoIterator<Item = T>,
-    ) -> Result<usize, tokio::sync::mpsc::error::SendError<T>> {
+    ) -> Result<usize, OwnerReadyTaskRouteClosed<T>> {
         // Materialize user-provided iterator code before taking the readiness
-        // lock. Only channel sends and the documented notification callback
+        // lock. Only queue mutation and the documented notification callback
         // may run inside the critical section.
         let mut tasks = tasks.into_iter().collect::<Vec<_>>().into_iter();
-        let mut readiness = lock_readiness(&self.readiness);
-        let mut enqueued = 0;
-        for task in tasks.by_ref() {
-            match self.sender.send(task) {
-                Ok(()) => enqueued += 1,
-                Err(error) => {
-                    // Drop arbitrary remaining payloads outside the readiness
-                    // lock; their destructors are not part of queue state and
-                    // must be free to call producer code without deadlocking.
-                    drop(readiness);
-                    drop(tasks);
-                    return Err(error);
-                }
-            }
+        let enqueued = tasks.len();
+        if enqueued == 0 {
+            return Ok(0);
         }
-        if enqueued != 0 && !readiness.ready {
-            readiness.ready = true;
-            self.signal.signal_ready();
+        let mut state = lock_state(&self.shared.state);
+        if !state.source_open {
+            let first = tasks.next().expect("nonempty producer batch");
+            // Drop arbitrary remaining payloads outside the shared-state lock;
+            // their destructors may call producer code for this source.
+            drop(state);
+            drop(tasks);
+            return Err(OwnerReadyTaskRouteClosed(first));
+        }
+        state.incoming.extend(tasks);
+        if !state.ready {
+            state.ready = true;
+            self.shared.signal.signal_ready();
         }
         Ok(enqueued)
     }
 
     pub fn same_source_as(&self, source: &OwnerReadyTaskSource<T, S>) -> bool {
-        self.sender.same_channel(&source.source.sender())
+        Arc::ptr_eq(&self.shared, &source.shared)
     }
 
     pub fn same_route_as(&self, other: &Self) -> bool {
-        self.sender.same_channel(&other.sender)
+        Arc::ptr_eq(&self.shared, &other.shared)
     }
 }
 
@@ -109,9 +135,8 @@ impl<T, S: OwnerTaskReadySignal> OwnerReadyTaskRoute<T, S> {
 /// cleared.
 #[derive(Debug)]
 pub struct OwnerReadyTaskSource<T, S> {
-    source: OwnerTaskSource<T>,
-    readiness: Arc<Mutex<OwnerTaskReadinessState>>,
-    signal: Arc<S>,
+    tasks: VecDeque<T>,
+    shared: Arc<OwnerReadyTaskShared<T, S>>,
 }
 
 impl<T, S> Default for OwnerReadyTaskSource<T, S>
@@ -126,17 +151,17 @@ where
 impl<T, S: OwnerTaskReadySignal> OwnerReadyTaskSource<T, S> {
     pub fn new(signal: S) -> Self {
         Self {
-            source: OwnerTaskSource::new(),
-            readiness: Arc::new(Mutex::new(OwnerTaskReadinessState::default())),
-            signal: Arc::new(signal),
+            tasks: VecDeque::new(),
+            shared: Arc::new(OwnerReadyTaskShared {
+                state: Mutex::new(OwnerReadyTaskState::default()),
+                signal,
+            }),
         }
     }
 
     pub fn route(&self) -> OwnerReadyTaskRoute<T, S> {
         OwnerReadyTaskRoute {
-            sender: self.source.sender(),
-            readiness: self.readiness.clone(),
-            signal: self.signal.clone(),
+            shared: self.shared.clone(),
         }
     }
 
@@ -145,41 +170,36 @@ impl<T, S: OwnerTaskReadySignal> OwnerReadyTaskSource<T, S> {
     /// This marks the source ready but deliberately publishes no wake. External
     /// producers must use [`OwnerReadyTaskRoute`] instead.
     pub fn enqueue_local(&mut self, task: T) {
-        let Self {
-            source, readiness, ..
-        } = self;
-        let mut readiness = lock_readiness(readiness);
-        source.enqueue_local(task);
-        readiness.ready = true;
+        let Self { tasks, shared } = self;
+        let mut state = lock_state(&shared.state);
+        tasks.push_back(task);
+        state.ready = true;
     }
 
     pub fn front(&mut self) -> Option<&T> {
-        let Self {
-            source, readiness, ..
-        } = self;
-        let mut readiness = lock_readiness(readiness);
-        let task = source.front();
-        readiness.ready = task.is_some();
+        let Self { tasks, shared } = self;
+        let mut state = lock_state(&shared.state);
+        tasks.append(&mut state.incoming);
+        let task = tasks.front();
+        state.ready = task.is_some();
         task
     }
 
     pub fn pop_front(&mut self) -> Option<T> {
-        let Self {
-            source, readiness, ..
-        } = self;
-        let mut readiness = lock_readiness(readiness);
-        let task = source.pop_front();
-        readiness.ready = !source.is_empty_local_only();
+        let Self { tasks, shared } = self;
+        let mut state = lock_state(&shared.state);
+        tasks.append(&mut state.incoming);
+        let task = tasks.pop_front();
+        state.ready = !tasks.is_empty();
         task
     }
 
     pub fn is_empty(&mut self) -> bool {
-        let Self {
-            source, readiness, ..
-        } = self;
-        let mut readiness = lock_readiness(readiness);
-        let is_empty = source.is_empty();
-        readiness.ready = !is_empty;
+        let Self { tasks, shared } = self;
+        let mut state = lock_state(&shared.state);
+        tasks.append(&mut state.incoming);
+        let is_empty = tasks.is_empty();
+        state.ready = !is_empty;
         is_empty
     }
 
@@ -187,13 +207,11 @@ impl<T, S: OwnerTaskReadySignal> OwnerReadyTaskSource<T, S> {
     /// dequeue/rearm. The predicate must be non-reentrant and must not call a
     /// producer route for this source.
     pub fn has_matching_task(&mut self, mut predicate: impl FnMut(&T) -> bool) -> bool {
-        let Self {
-            source, readiness, ..
-        } = self;
-        let mut readiness = lock_readiness(readiness);
-        let (has_match, is_empty) =
-            source.with_tasks_mut(|tasks| (tasks.iter().any(&mut predicate), tasks.is_empty()));
-        readiness.ready = !is_empty;
+        let Self { tasks, shared } = self;
+        let mut state = lock_state(&shared.state);
+        tasks.append(&mut state.incoming);
+        let has_match = tasks.iter().any(&mut predicate);
+        state.ready = !tasks.is_empty();
         has_match
     }
 
@@ -203,39 +221,48 @@ impl<T, S: OwnerTaskReadySignal> OwnerReadyTaskSource<T, S> {
     /// The callback runs under the source readiness lock and must not invoke a
     /// producer route for this source.
     pub fn with_tasks_mut<R>(&mut self, operation: impl FnOnce(&mut VecDeque<T>) -> R) -> R {
-        let Self {
-            source, readiness, ..
-        } = self;
-        let mut readiness = lock_readiness(readiness);
-        source.with_tasks_mut(|tasks| {
-            let result = operation(tasks);
-            readiness.ready = !tasks.is_empty();
-            result
-        })
+        let Self { tasks, shared } = self;
+        let mut state = lock_state(&shared.state);
+        tasks.append(&mut state.incoming);
+        let result = operation(tasks);
+        state.ready = !tasks.is_empty();
+        result
     }
 
-    /// Inspect only payloads already accepted by the owner. Producer-channel
+    /// Inspect only payloads already accepted by the owner. Pending producer
     /// arrivals are deliberately excluded so derived-index assertions do not
     /// mutate source state.
     pub fn with_local_tasks<R>(&self, operation: impl FnOnce(&VecDeque<T>) -> R) -> R {
-        self.source.with_local_tasks(operation)
+        operation(&self.tasks)
     }
 
     /// Drop every accepted task and rearm the producer readiness edge.
     pub fn clear_local(&mut self) {
-        let Self {
-            source, readiness, ..
-        } = self;
-        let mut readiness = lock_readiness(readiness);
-        source.clear_local();
-        readiness.ready = false;
+        let Self { tasks, shared } = self;
+        let mut discarded = std::mem::take(tasks);
+        {
+            let mut state = lock_state(&shared.state);
+            discarded.append(&mut state.incoming);
+            state.ready = false;
+        }
+        drop(discarded);
     }
 }
 
-fn lock_readiness(
-    readiness: &Mutex<OwnerTaskReadinessState>,
-) -> MutexGuard<'_, OwnerTaskReadinessState> {
-    readiness.lock()
+impl<T, S> Drop for OwnerReadyTaskSource<T, S> {
+    fn drop(&mut self) {
+        let incoming = {
+            let mut state = lock_state(&self.shared.state);
+            state.source_open = false;
+            state.ready = false;
+            std::mem::take(&mut state.incoming)
+        };
+        drop(incoming);
+    }
+}
+
+fn lock_state<T>(state: &Mutex<OwnerReadyTaskState<T>>) -> MutexGuard<'_, OwnerReadyTaskState<T>> {
+    state.lock()
 }
 
 #[cfg(test)]
@@ -371,6 +398,53 @@ mod tests {
 
         assert!(route.send_and_signal_if_newly_ready(1).is_err());
         assert_eq!(wakes.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn a_closed_source_rejects_a_batch_at_its_first_payload() {
+        let (source, wakes) = counting_source();
+        let route = source.route();
+        drop(source);
+
+        let error = route
+            .send_all_and_signal_if_newly_ready([1, 2, 3])
+            .expect_err("closed source must reject a nonempty batch");
+        assert_eq!(error.0, 1);
+        assert_eq!(
+            route.send_all_and_signal_if_newly_ready([]).unwrap(),
+            0,
+            "an empty batch remains a no-op after source closure"
+        );
+        assert_eq!(wakes.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn route_identity_uses_the_shared_source() {
+        let (source, _wakes) = counting_source::<usize>();
+        let first = source.route();
+        let clone = first.clone();
+        let (other_source, _other_wakes) = counting_source::<usize>();
+        let other = other_source.route();
+
+        assert!(first.same_source_as(&source));
+        assert!(first.same_route_as(&clone));
+        assert!(!first.same_source_as(&other_source));
+        assert!(!first.same_route_as(&other));
+    }
+
+    #[test]
+    fn local_inspection_excludes_unaccepted_producer_arrivals() {
+        let (mut source, _wakes) = counting_source();
+        let route = source.route();
+        source.enqueue_local(1);
+        route.send_and_signal_if_newly_ready(2).unwrap();
+
+        assert_eq!(
+            source.with_local_tasks(|tasks| tasks.iter().copied().collect::<Vec<_>>()),
+            vec![1]
+        );
+        assert_eq!(source.pop_front(), Some(1));
+        assert_eq!(source.pop_front(), Some(2));
     }
 
     #[test]

--- a/moli-renderer-v8/src/page_task_queue.rs
+++ b/moli-renderer-v8/src/page_task_queue.rs
@@ -37,6 +37,7 @@ mod parser_owned_module_continuation;
 mod popup_load_event;
 mod post_domcontentloaded_runtime;
 mod post_parse_owner_work;
+mod ready_signal;
 mod rendering_update;
 mod resource_completions;
 mod senders;
@@ -379,6 +380,7 @@ pub(crate) use self::post_parse_owner_work::{
     PostParseLifecycleQueueStats, PostParseLifecycleWork, PostParsePageOwnedWork,
     post_parse_lifecycle_queue_stats,
 };
+use self::ready_signal::RendererPageTaskReadySignal;
 #[cfg(test)]
 pub(crate) use self::rendering_update::RendererPageRenderingUpdateHead;
 pub(crate) use self::rendering_update::{

--- a/moli-renderer-v8/src/page_task_queue/child_frame_task.rs
+++ b/moli-renderer-v8/src/page_task_queue/child_frame_task.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     document_runtime::DomHandle,
@@ -11,7 +11,10 @@ use crate::{
     runtime::{PageOwnerTurnOutcome, RendererDocumentToken},
 };
 
-use super::{RendererOwnerWakeSender, RendererPageChildRealmMaterializationTarget};
+use super::{
+    RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageChildRealmMaterializationTarget,
+    RendererPageTaskReadySignal,
+};
 
 /// PageVm-local ledger key for one child document-script execution task.
 ///
@@ -514,7 +517,7 @@ impl RendererPageChildClassicScriptSourceLoadRouteClosed {
 #[derive(Clone, Debug)]
 pub(crate) struct RendererPageChildFrameTaskRoute {
     task_route:
-        OwnerReadyTaskRoute<ReadyPageTask<RendererPageChildFrameTask>, ChildFrameTaskReadySignal>,
+        OwnerReadyTaskRoute<ReadyPageTask<RendererPageChildFrameTask>, RendererPageTaskReadySignal>,
     owner_wake: RendererOwnerWakeSender,
 }
 
@@ -539,7 +542,7 @@ impl RendererPageChildFrameTaskRoute {
 #[derive(Clone, Debug)]
 pub(crate) struct RendererPageChildFrameTaskSender {
     task_route:
-        OwnerReadyTaskRoute<ReadyPageTask<RendererPageChildFrameTask>, ChildFrameTaskReadySignal>,
+        OwnerReadyTaskRoute<ReadyPageTask<RendererPageChildFrameTask>, RendererPageTaskReadySignal>,
     owner_wake: RendererOwnerWakeSender,
     root_document: RendererDocumentToken,
 }
@@ -640,31 +643,23 @@ impl RendererPageChildFrameTaskSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct ChildFrameTaskReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for ChildFrameTaskReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_child_frame_task();
-    }
-}
-
 /// Unique Page-lifetime consumer for the child-frame task family.
 #[derive(Debug)]
 pub(crate) struct RendererPageChildFrameTaskSource {
-    source:
-        OwnerReadyTaskSource<ReadyPageTask<RendererPageChildFrameTask>, ChildFrameTaskReadySignal>,
+    source: OwnerReadyTaskSource<
+        ReadyPageTask<RendererPageChildFrameTask>,
+        RendererPageTaskReadySignal,
+    >,
     owner_wake: RendererOwnerWakeSender,
 }
 
 impl RendererPageChildFrameTaskSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(ChildFrameTaskReadySignal {
-                owner_wake: owner_wake.clone(),
-            }),
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
+                owner_wake.clone(),
+                RendererOwnerWakeSource::ChildFrameTask,
+            )),
             owner_wake,
         }
     }

--- a/moli-renderer-v8/src/page_task_queue/child_module_dependency_fetch_start.rs
+++ b/moli-renderer-v8/src/page_task_queue/child_module_dependency_fetch_start.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, sync::Arc};
 
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 use parking_lot::Mutex;
 
 use crate::{
@@ -13,7 +13,7 @@ use crate::{
     runtime::{PageOwnerTurnOutcome, RendererDocumentToken},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Stable Page namespace plus the exact child Document/realm that owns one
 /// static-module dependency fetch start.
@@ -131,7 +131,7 @@ impl RendererPageChildModuleDependencyFetchStartEnqueue {
 pub(crate) struct RendererPageChildModuleDependencyFetchStartRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageChildModuleDependencyFetchStartTask>,
-        ChildModuleDependencyFetchStartReadySignal,
+        RendererPageTaskReadySignal,
     >,
     pending_keys: Arc<Mutex<HashSet<RendererPageChildModuleDependencyFetchStartPendingKey>>>,
 }
@@ -161,7 +161,7 @@ impl RendererPageChildModuleDependencyFetchStartRoute {
 pub(crate) struct RendererPageChildModuleDependencyFetchStartSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageChildModuleDependencyFetchStartTask>,
-        ChildModuleDependencyFetchStartReadySignal,
+        RendererPageTaskReadySignal,
     >,
     pending_keys: Arc<Mutex<HashSet<RendererPageChildModuleDependencyFetchStartPendingKey>>>,
     root_document: RendererDocumentToken,
@@ -197,23 +197,12 @@ impl RendererPageChildModuleDependencyFetchStartSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct ChildModuleDependencyFetchStartReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for ChildModuleDependencyFetchStartReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_child_module_dependency_fetch_start();
-    }
-}
-
 /// Unique Page-lifetime consumer for child module dependency fetch starts.
 #[derive(Debug)]
 pub(crate) struct RendererPageChildModuleDependencyFetchStartSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageChildModuleDependencyFetchStartTask>,
-        ChildModuleDependencyFetchStartReadySignal,
+        RendererPageTaskReadySignal,
     >,
     pending_keys: Arc<Mutex<HashSet<RendererPageChildModuleDependencyFetchStartPendingKey>>>,
 }
@@ -222,9 +211,10 @@ impl RendererPageChildModuleDependencyFetchStartSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         let pending_keys = Arc::new(Mutex::new(HashSet::new()));
         Self {
-            source: OwnerReadyTaskSource::new(ChildModuleDependencyFetchStartReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::ChildModuleDependencyFetchStart,
+            )),
             pending_keys,
         }
     }

--- a/moli-renderer-v8/src/page_task_queue/child_module_script_terminal.rs
+++ b/moli-renderer-v8/src/page_task_queue/child_module_script_terminal.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     frame_owner_model::{
@@ -9,7 +9,7 @@ use crate::{
     runtime::{PageOwnerTurnOutcome, RendererDocumentToken},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Stable Page namespace plus the exact child Document/realm that owns one
 /// module-map terminal fanout action.
@@ -94,7 +94,7 @@ impl RendererPageChildModuleScriptTerminalRouteClosed {
 pub(crate) struct RendererPageChildModuleScriptTerminalRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageChildModuleScriptTerminalTask>,
-        ChildModuleScriptTerminalReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -122,7 +122,7 @@ impl RendererPageChildModuleScriptTerminalRoute {
 pub(crate) struct RendererPageChildModuleScriptTerminalSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageChildModuleScriptTerminalTask>,
-        ChildModuleScriptTerminalReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -143,30 +143,22 @@ impl RendererPageChildModuleScriptTerminalSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct ChildModuleScriptTerminalReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for ChildModuleScriptTerminalReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_child_module_script_terminal();
-    }
-}
-
 /// Unique Page-lifetime consumer for child module terminal fanout actions.
 #[derive(Debug)]
 pub(crate) struct RendererPageChildModuleScriptTerminalSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageChildModuleScriptTerminalTask>,
-        ChildModuleScriptTerminalReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageChildModuleScriptTerminalSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(ChildModuleScriptTerminalReadySignal { owner_wake }),
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
+                owner_wake,
+                RendererOwnerWakeSource::ChildModuleScriptTerminal,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/child_modulepreload_event_action.rs
+++ b/moli-renderer-v8/src/page_task_queue/child_modulepreload_event_action.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     frame_owner_model::{
@@ -9,7 +9,7 @@ use crate::{
     runtime::{PageOwnerTurnOutcome, RendererDocumentToken},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Stable Page namespace plus the exact child Document/realm that owns one
 /// modulepreload load/error event action.
@@ -89,7 +89,7 @@ impl RendererPageChildModulepreloadEventActionRouteClosed {
 pub(crate) struct RendererPageChildModulepreloadEventActionRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageChildModulepreloadEventActionTask>,
-        ChildModulepreloadEventActionReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -113,7 +113,7 @@ impl RendererPageChildModulepreloadEventActionRoute {
 pub(crate) struct RendererPageChildModulepreloadEventActionSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageChildModulepreloadEventActionTask>,
-        ChildModulepreloadEventActionReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -134,32 +134,22 @@ impl RendererPageChildModulepreloadEventActionSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct ChildModulepreloadEventActionReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for ChildModulepreloadEventActionReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_child_modulepreload_event_action();
-    }
-}
-
 /// Unique Page-lifetime consumer for child modulepreload event actions.
 #[derive(Debug)]
 pub(crate) struct RendererPageChildModulepreloadEventActionSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageChildModulepreloadEventActionTask>,
-        ChildModulepreloadEventActionReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageChildModulepreloadEventActionSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(ChildModulepreloadEventActionReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::ChildModulepreloadEventAction,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/dedicated_worker_client_event.rs
+++ b/moli-renderer-v8/src/page_task_queue/dedicated_worker_client_event.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     native_bridge::WindowExecutionContextIdentity,
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Exact Page-side Worker wrapper that owns one client-facing event.
 ///
@@ -168,7 +168,7 @@ pub(crate) struct RendererPageDedicatedWorkerClientEventRouteClosed;
 pub(crate) struct RendererPageDedicatedWorkerClientEventRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageDedicatedWorkerClientEventTask>,
-        RendererPageDedicatedWorkerClientEventReadySignal,
+        RendererPageTaskReadySignal,
     >,
     page_token: crate::runtime::RendererPageToken,
 }
@@ -195,7 +195,7 @@ impl RendererPageDedicatedWorkerClientEventRoute {
 pub(crate) struct RendererPageDedicatedWorkerClientEventSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageDedicatedWorkerClientEventTask>,
-        RendererPageDedicatedWorkerClientEventReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
     page_token: crate::runtime::RendererPageToken,
@@ -227,7 +227,7 @@ impl RendererPageDedicatedWorkerClientEventSender {
 pub(crate) struct RendererPageDedicatedWorkerClientEventProducer {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageDedicatedWorkerClientEventTask>,
-        RendererPageDedicatedWorkerClientEventReadySignal,
+        RendererPageTaskReadySignal,
     >,
     owner: RendererPageDedicatedWorkerClientEventOwner,
 }
@@ -249,23 +249,12 @@ impl RendererPageDedicatedWorkerClientEventProducer {
     }
 }
 
-#[derive(Clone, Debug)]
-struct RendererPageDedicatedWorkerClientEventReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageDedicatedWorkerClientEventReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_dedicated_worker_client_event();
-    }
-}
-
 /// Unique Page-lifetime consumer for DedicatedWorker client events.
 #[derive(Debug)]
 pub(crate) struct RendererPageDedicatedWorkerClientEventSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageDedicatedWorkerClientEventTask>,
-        RendererPageDedicatedWorkerClientEventReadySignal,
+        RendererPageTaskReadySignal,
     >,
     page_token: crate::runtime::RendererPageToken,
 }
@@ -274,9 +263,10 @@ impl RendererPageDedicatedWorkerClientEventSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         let page_token = owner_wake.token();
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageDedicatedWorkerClientEventReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::DedicatedWorkerClientEvent,
+            )),
             page_token,
         }
     }

--- a/moli-renderer-v8/src/page_task_queue/dom_manipulation.rs
+++ b/moli-renderer-v8/src/page_task_queue/dom_manipulation.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     resource_ready::{ReadyPageTask, RendererPageTaskReadyMetadata},
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use super::{
-    RendererOwnerWakeSender,
+    RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal,
     broadcast_channel_delivery::{
         RendererPageBroadcastChannelDeliveryOwner, RendererPageBroadcastChannelDeliverySender,
         RendererPageBroadcastChannelDeliveryTask,
@@ -216,7 +216,7 @@ impl RendererPageDomManipulationSender {
 pub(crate) struct RendererPageDomManipulationRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageDomManipulationTask>,
-        RendererPageDomManipulationReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -243,23 +243,12 @@ impl RendererPageDomManipulationRoute {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RendererPageDomManipulationRouteClosed;
 
-#[derive(Clone, Debug)]
-struct RendererPageDomManipulationReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageDomManipulationReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_dom_manipulation_task();
-    }
-}
-
 /// Unique consumer for the Page's HTML DOM-manipulation task source.
 #[derive(Debug)]
 pub(crate) struct RendererPageDomManipulationSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageDomManipulationTask>,
-        RendererPageDomManipulationReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -282,9 +271,10 @@ impl RendererPageDomManipulationSource {
 
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageDomManipulationReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::DomManipulationTask,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/dynamic_import_owner_action.rs
+++ b/moli-renderer-v8/src/page_task_queue/dynamic_import_owner_action.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     frame_owner_model::{
@@ -9,7 +9,7 @@ use crate::{
     runtime::{PageOwnerTurnOutcome, RendererDocumentToken},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Exact owner of one child dynamic-import owner action.
 ///
@@ -86,7 +86,7 @@ pub(crate) struct RendererPageDynamicImportOwnerActionRouteClosed;
 pub(crate) struct RendererPageDynamicImportOwnerActionRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageDynamicImportOwnerActionTask>,
-        RendererPageDynamicImportOwnerActionReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -112,7 +112,7 @@ impl RendererPageDynamicImportOwnerActionRoute {
 pub(crate) struct RendererPageDynamicImportOwnerActionSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageDynamicImportOwnerActionTask>,
-        RendererPageDynamicImportOwnerActionReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -121,7 +121,7 @@ impl RendererPageDynamicImportOwnerActionSender {
     fn new(
         task_route: OwnerReadyTaskRoute<
             ReadyPageTask<RendererPageDynamicImportOwnerActionTask>,
-            RendererPageDynamicImportOwnerActionReadySignal,
+            RendererPageTaskReadySignal,
         >,
         root_document: RendererDocumentToken,
     ) -> Self {
@@ -152,31 +152,21 @@ impl RendererPageDynamicImportOwnerActionSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct RendererPageDynamicImportOwnerActionReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageDynamicImportOwnerActionReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_dynamic_import_owner_action();
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct RendererPageDynamicImportOwnerActionSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageDynamicImportOwnerActionTask>,
-        RendererPageDynamicImportOwnerActionReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageDynamicImportOwnerActionSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageDynamicImportOwnerActionReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::DynamicImportOwnerAction,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/indexed_db_task.rs
+++ b/moli-renderer-v8/src/page_task_queue/indexed_db_task.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     context_bootstrap::IndexedDbTaskId,
@@ -7,7 +7,7 @@ use crate::{
     runtime::{PageOwnerTurnOutcome, RendererDocumentToken},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// One concrete unit of Page-side IndexedDB work.
 ///
@@ -78,7 +78,7 @@ pub(crate) struct RendererPageIndexedDbTaskRouteClosed;
 #[derive(Clone, Debug)]
 pub(crate) struct RendererPageIndexedDbTaskRoute {
     task_route:
-        OwnerReadyTaskRoute<ReadyPageTask<RendererPageIndexedDbTask>, IndexedDbTaskReadySignal>,
+        OwnerReadyTaskRoute<ReadyPageTask<RendererPageIndexedDbTask>, RendererPageTaskReadySignal>,
     owner_wake: RendererOwnerWakeSender,
 }
 
@@ -103,7 +103,7 @@ impl RendererPageIndexedDbTaskRoute {
 #[derive(Clone, Debug)]
 pub(crate) struct RendererPageIndexedDbTaskSender {
     task_route:
-        OwnerReadyTaskRoute<ReadyPageTask<RendererPageIndexedDbTask>, IndexedDbTaskReadySignal>,
+        OwnerReadyTaskRoute<ReadyPageTask<RendererPageIndexedDbTask>, RendererPageTaskReadySignal>,
     owner_wake: RendererOwnerWakeSender,
     root_document: RendererDocumentToken,
 }
@@ -132,31 +132,21 @@ impl RendererPageIndexedDbTaskSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct IndexedDbTaskReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for IndexedDbTaskReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_indexed_db_task();
-    }
-}
-
 /// Unique Page-lifetime consumer for Page-side IndexedDB tasks.
 #[derive(Debug)]
 pub(crate) struct RendererPageIndexedDbTaskSource {
     source:
-        OwnerReadyTaskSource<ReadyPageTask<RendererPageIndexedDbTask>, IndexedDbTaskReadySignal>,
+        OwnerReadyTaskSource<ReadyPageTask<RendererPageIndexedDbTask>, RendererPageTaskReadySignal>,
     owner_wake: RendererOwnerWakeSender,
 }
 
 impl RendererPageIndexedDbTaskSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(IndexedDbTaskReadySignal {
-                owner_wake: owner_wake.clone(),
-            }),
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
+                owner_wake.clone(),
+                RendererOwnerWakeSource::IndexedDbTask,
+            )),
             owner_wake,
         }
     }

--- a/moli-renderer-v8/src/page_task_queue/internal_loading.rs
+++ b/moli-renderer-v8/src/page_task_queue/internal_loading.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, time::Instant};
 
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     frame_owner_model::FrameDocumentTaskOwner,
@@ -10,6 +10,7 @@ use crate::{
 
 use super::{
     PageOwnedInternalLoadingTask, PageOwnedInternalLoadingTaskEffect, RendererOwnerWakeSender,
+    RendererOwnerWakeSource, RendererPageTaskReadySignal,
 };
 
 /// PageVm namespace plus the exact main Document that produced one HTML
@@ -61,7 +62,7 @@ pub(crate) struct RendererPageInternalLoadingRouteClosed;
 pub(crate) struct RendererPageInternalLoadingRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageInternalLoadingTask>,
-        InternalLoadingReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -86,7 +87,7 @@ impl RendererPageInternalLoadingRoute {
 pub(crate) struct RendererPageInternalLoadingSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageInternalLoadingTask>,
-        InternalLoadingReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -110,30 +111,22 @@ impl RendererPageInternalLoadingSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct InternalLoadingReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for InternalLoadingReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_internal_loading_task();
-    }
-}
-
 /// Unique Page-lifetime consumer for HTML internal-loading tasks.
 #[derive(Debug)]
 pub(crate) struct RendererPageInternalLoadingSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageInternalLoadingTask>,
-        InternalLoadingReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageInternalLoadingSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(InternalLoadingReadySignal { owner_wake }),
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
+                owner_wake,
+                RendererOwnerWakeSource::InternalLoadingTask,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/main_document_runtime.rs
+++ b/moli-renderer-v8/src/page_task_queue/main_document_runtime.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     document_script_scheduler::MainParserAsyncModuleAdmission,
@@ -14,7 +14,8 @@ use super::{
     PageMainNativeModuleTargetEffect, PageNativeModuleOwnerEventTurnAction,
     PageParserAsyncModuleAdmissionTargetEffect, PageParserAsyncModuleAdmissionTurnAction,
     PageParserOwnedModuleContinuationTargetEffect, PageParserOwnedModuleContinuationTurnAction,
-    PostParsePageOwnedWork, RendererOwnerWakeSender,
+    PostParsePageOwnedWork, RendererOwnerWakeSender, RendererOwnerWakeSource,
+    RendererPageTaskReadySignal,
 };
 
 pub(crate) type RendererPageMainDocumentRuntimeOwner = super::RendererPageMainDocumentTaskOwner;
@@ -118,7 +119,7 @@ pub(crate) struct RendererPageMainDocumentRuntimeRouteClosed;
 pub(crate) struct RendererPageMainDocumentRuntimeRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageMainDocumentRuntimeTask>,
-        RendererPageMainDocumentRuntimeReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -144,7 +145,7 @@ impl RendererPageMainDocumentRuntimeRoute {
 pub(crate) struct RendererPageMainDocumentRuntimeSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageMainDocumentRuntimeTask>,
-        RendererPageMainDocumentRuntimeReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -371,31 +372,21 @@ pub(crate) enum RendererPageMainDocumentRuntimeAdmissionError {
     TargetMismatch,
 }
 
-#[derive(Clone, Debug)]
-struct RendererPageMainDocumentRuntimeReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageMainDocumentRuntimeReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_main_document_runtime_task();
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct RendererPageMainDocumentRuntimeSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageMainDocumentRuntimeTask>,
-        RendererPageMainDocumentRuntimeReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageMainDocumentRuntimeSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageMainDocumentRuntimeReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::MainDocumentRuntimeTask,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/media_element_event.rs
+++ b/moli-renderer-v8/src/page_task_queue/media_element_event.rs
@@ -95,7 +95,7 @@ mod tests {
         );
         let mut source = RendererPageMediaElementEventSource::new(
             owner_wake,
-            RendererOwnerWakeSender::signal_media_element_event_task,
+            RendererOwnerWakeSource::MediaElementEventTask,
         );
         let sender = source.route().sender(root_document());
 
@@ -138,7 +138,7 @@ mod tests {
                 wake_tx,
                 RendererPageToken::new_for_testing(root_document().page_id),
             ),
-            RendererOwnerWakeSender::signal_media_element_event_task,
+            RendererOwnerWakeSource::MediaElementEventTask,
         );
         let sender = source.route().sender(root_document());
         drop(source);

--- a/moli-renderer-v8/src/page_task_queue/message_port_delivery.rs
+++ b/moli-renderer-v8/src/page_task_queue/message_port_delivery.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     native_bridge::WindowExecutionContextIdentity,
@@ -7,7 +7,7 @@ use crate::{
     types::MessagePortId,
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Exact Page-side attachment that owned a MessagePort when delivery became
 /// runnable.
@@ -67,7 +67,7 @@ pub(crate) struct RendererPageMessagePortDeliveryRouteClosed;
 pub(crate) struct RendererPageMessagePortDeliveryRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageMessagePortDeliveryTask>,
-        RendererPageMessagePortDeliveryReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -93,7 +93,7 @@ impl RendererPageMessagePortDeliveryRoute {
 pub(crate) struct RendererPageMessagePortDeliverySender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageMessagePortDeliveryTask>,
-        RendererPageMessagePortDeliveryReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -118,7 +118,7 @@ impl RendererPageMessagePortDeliverySender {
 pub(crate) struct RendererPageMessagePortDeliveryProducer {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageMessagePortDeliveryTask>,
-        RendererPageMessagePortDeliveryReadySignal,
+        RendererPageTaskReadySignal,
     >,
     owner: RendererPageMessagePortDeliveryOwner,
 }
@@ -141,32 +141,22 @@ impl RendererPageMessagePortDeliveryProducer {
     }
 }
 
-#[derive(Clone, Debug)]
-struct RendererPageMessagePortDeliveryReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageMessagePortDeliveryReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_message_port_delivery();
-    }
-}
-
 /// Unique Page-lifetime consumer for page-side MessagePort delivery tasks.
 #[derive(Debug)]
 pub(crate) struct RendererPageMessagePortDeliverySource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageMessagePortDeliveryTask>,
-        RendererPageMessagePortDeliveryReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageMessagePortDeliverySource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageMessagePortDeliveryReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::MessagePortDelivery,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/module_reaction.rs
+++ b/moli-renderer-v8/src/page_task_queue/module_reaction.rs
@@ -1,6 +1,6 @@
 use std::{fmt, num::NonZeroUsize};
 
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     frame_owner_model::{FrameDocumentTaskOwner, FrameRealmId},
@@ -10,7 +10,7 @@ use crate::{
     types::ScriptErrorConstructorKind,
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Exact PageVm-local target captured by a module Promise reaction callback.
 ///
@@ -197,7 +197,7 @@ pub(crate) struct RendererPageModuleReactionRouteClosed;
 pub(crate) struct RendererPageModuleReactionRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageModuleReactionTask>,
-        RendererPageModuleReactionReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -223,7 +223,7 @@ impl RendererPageModuleReactionRoute {
 pub(crate) struct RendererPageModuleReactionSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageModuleReactionTask>,
-        RendererPageModuleReactionReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -241,30 +241,22 @@ impl RendererPageModuleReactionSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct RendererPageModuleReactionReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageModuleReactionReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_module_reaction();
-    }
-}
-
 /// Unique stable Page consumer for module reaction continuation records.
 #[derive(Debug)]
 pub(crate) struct RendererPageModuleReactionSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageModuleReactionTask>,
-        RendererPageModuleReactionReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageModuleReactionSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageModuleReactionReadySignal { owner_wake }),
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
+                owner_wake,
+                RendererOwnerWakeSource::ModuleReaction,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/modulepreload_start.rs
+++ b/moli-renderer-v8/src/page_task_queue/modulepreload_start.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     frame_owner_model::{
@@ -9,7 +9,7 @@ use crate::{
     runtime::{PageOwnerTurnOutcome, RendererDocumentToken},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Exact owner of one modulepreload start task in the stable Page source.
 ///
@@ -75,7 +75,7 @@ pub(crate) struct RendererPageModulepreloadStartRouteClosed;
 pub(crate) struct RendererPageModulepreloadStartRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageModulepreloadStartTask>,
-        RendererPageModulepreloadStartReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -102,7 +102,7 @@ impl RendererPageModulepreloadStartRoute {
 pub(crate) struct RendererPageModulepreloadStartSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageModulepreloadStartTask>,
-        RendererPageModulepreloadStartReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -111,7 +111,7 @@ impl RendererPageModulepreloadStartSender {
     fn new(
         task_route: OwnerReadyTaskRoute<
             ReadyPageTask<RendererPageModulepreloadStartTask>,
-            RendererPageModulepreloadStartReadySignal,
+            RendererPageTaskReadySignal,
         >,
         root_document: RendererDocumentToken,
     ) -> Self {
@@ -138,32 +138,22 @@ impl RendererPageModulepreloadStartSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct RendererPageModulepreloadStartReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageModulepreloadStartReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_modulepreload_start();
-    }
-}
-
 /// Unique owner-side source shared by all PageVm generations of one Page.
 #[derive(Debug)]
 pub(crate) struct RendererPageModulepreloadStartSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageModulepreloadStartTask>,
-        RendererPageModulepreloadStartReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageModulepreloadStartSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageModulepreloadStartReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::ModulepreloadStart,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/navigation_and_traversal.rs
+++ b/moli-renderer-v8/src/page_task_queue/navigation_and_traversal.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     resource_ready::{ReadyPageTask, RendererPageTaskReadyMetadata},
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use super::{
-    RendererOwnerWakeSender,
+    RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal,
     child_navigation_commit::{
         PageChildNavigationCommitTurnAction, RendererPageChildNavigationCommitOwner,
         RendererPageChildNavigationCommitSender, RendererPageChildNavigationCommitTask,
@@ -122,7 +122,7 @@ impl RendererPageNavigationAndTraversalSender {
 pub(crate) struct RendererPageNavigationAndTraversalRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageNavigationAndTraversalTask>,
-        RendererPageNavigationAndTraversalReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -144,32 +144,22 @@ impl RendererPageNavigationAndTraversalRoute {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct RendererPageNavigationAndTraversalRouteClosed;
 
-#[derive(Clone, Debug)]
-struct RendererPageNavigationAndTraversalReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageNavigationAndTraversalReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_navigation_and_traversal_task();
-    }
-}
-
 /// Unique Page-lifetime consumer for the HTML navigation-and-traversal source.
 #[derive(Debug)]
 pub(crate) struct RendererPageNavigationAndTraversalSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageNavigationAndTraversalTask>,
-        RendererPageNavigationAndTraversalReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageNavigationAndTraversalSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageNavigationAndTraversalReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::NavigationAndTraversalTask,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/opfs_task.rs
+++ b/moli-renderer-v8/src/page_task_queue/opfs_task.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     native_bridge::WindowExecutionContextIdentity,
@@ -7,7 +7,7 @@ use crate::{
     runtime::{PageOwnerTurnOutcome, RendererDocumentToken},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// PageVm-local identity of one pending OPFS settlement.
 ///
@@ -106,7 +106,8 @@ pub(crate) struct RendererPageOpfsTaskRouteClosed;
 
 #[derive(Clone, Debug)]
 pub(crate) struct RendererPageOpfsTaskRoute {
-    task_route: OwnerReadyTaskRoute<ReadyPageTask<RendererPageOpfsTask>, OpfsTaskReadySignal>,
+    task_route:
+        OwnerReadyTaskRoute<ReadyPageTask<RendererPageOpfsTask>, RendererPageTaskReadySignal>,
 }
 
 impl RendererPageOpfsTaskRoute {
@@ -127,7 +128,8 @@ impl RendererPageOpfsTaskRoute {
 
 #[derive(Clone, Debug)]
 pub(crate) struct RendererPageOpfsTaskSender {
-    task_route: OwnerReadyTaskRoute<ReadyPageTask<RendererPageOpfsTask>, OpfsTaskReadySignal>,
+    task_route:
+        OwnerReadyTaskRoute<ReadyPageTask<RendererPageOpfsTask>, RendererPageTaskReadySignal>,
     root_document: RendererDocumentToken,
 }
 
@@ -146,7 +148,8 @@ impl RendererPageOpfsTaskSender {
 
 #[derive(Debug)]
 pub(crate) struct RendererPageOpfsTaskProducer {
-    task_route: OwnerReadyTaskRoute<ReadyPageTask<RendererPageOpfsTask>, OpfsTaskReadySignal>,
+    task_route:
+        OwnerReadyTaskRoute<ReadyPageTask<RendererPageOpfsTask>, RendererPageTaskReadySignal>,
     owner: RendererPageOpfsTaskOwner,
 }
 
@@ -173,26 +176,18 @@ impl RendererPageOpfsTaskProducer {
     }
 }
 
-#[derive(Clone, Debug)]
-struct OpfsTaskReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for OpfsTaskReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_opfs_task();
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct RendererPageOpfsTaskSource {
-    source: OwnerReadyTaskSource<ReadyPageTask<RendererPageOpfsTask>, OpfsTaskReadySignal>,
+    source: OwnerReadyTaskSource<ReadyPageTask<RendererPageOpfsTask>, RendererPageTaskReadySignal>,
 }
 
 impl RendererPageOpfsTaskSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(OpfsTaskReadySignal { owner_wake }),
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
+                owner_wake,
+                RendererOwnerWakeSource::OpfsTask,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/owner_sources.rs
+++ b/moli-renderer-v8/src/page_task_queue/owner_sources.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 use std::{cell::RefCell, rc::Rc};
 
 use super::{
-    PageRuntimeWakeSignal, RendererOwnerWakeSender,
+    PageRuntimeWakeSignal, RendererOwnerWakeSender, RendererOwnerWakeSource,
     child_frame_task::{
         RendererPageChildFrameTask, RendererPageChildFrameTaskOwner,
         RendererPageChildFrameTaskRoute, RendererPageChildFrameTaskSender,
@@ -618,25 +618,25 @@ impl RendererPageOwnedTaskSources {
         let dom_manipulation = RendererPageDomManipulationSource::new(owner_wake.clone());
         let user_interaction = RendererPageUserInteractionSource::new(
             owner_wake.clone(),
-            RendererOwnerWakeSender::signal_user_interaction_task,
+            RendererOwnerWakeSource::UserInteractionTask,
         );
         let file_reading = RendererPageFileReadingSource::new(
             owner_wake.clone(),
-            RendererOwnerWakeSender::signal_file_reading_task,
+            RendererOwnerWakeSource::FileReadingTask,
         );
         let misc_platform_api = RendererPageMiscPlatformApiSource::new(
             owner_wake.clone(),
-            RendererOwnerWakeSender::signal_misc_platform_api_task,
+            RendererOwnerWakeSource::MiscPlatformApiTask,
         );
         let navigation_and_traversal =
             RendererPageNavigationAndTraversalSource::new(owner_wake.clone());
         let rendering_update = RendererPageRenderingUpdateSource::new(
             owner_wake.clone(),
-            RendererOwnerWakeSender::signal_rendering_update_task,
+            RendererOwnerWakeSource::RenderingUpdateTask,
         );
         let media_element_event = RendererPageMediaElementEventSource::new(
             owner_wake.clone(),
-            RendererOwnerWakeSender::signal_media_element_event_task,
+            RendererOwnerWakeSource::MediaElementEventTask,
         );
         let dedicated_worker_client_event =
             RendererPageDedicatedWorkerClientEventSource::new(owner_wake.clone());

--- a/moli-renderer-v8/src/page_task_queue/owner_sources/conformance_tests.rs
+++ b/moli-renderer-v8/src/page_task_queue/owner_sources/conformance_tests.rs
@@ -64,8 +64,8 @@ use crate::{
 };
 
 use super::{
-    PageRuntimeWakeSignal, RendererOwnerWakeSender, RendererPageChildFrameTaskSource,
-    RendererPageChildModuleDependencyFetchStartSender,
+    PageRuntimeWakeSignal, RendererOwnerWakeSender, RendererOwnerWakeSource,
+    RendererPageChildFrameTaskSource, RendererPageChildModuleDependencyFetchStartSender,
     RendererPageChildModuleDependencyFetchStartSource, RendererPageChildModuleScriptTerminalSender,
     RendererPageChildModuleScriptTerminalSource, RendererPageChildModulepreloadEventActionSender,
     RendererPageChildModulepreloadEventActionSource, RendererPageDedicatedWorkerClientEventSource,
@@ -1073,7 +1073,7 @@ impl RenderingUpdateLane {
                 wake_tx,
                 RendererPageToken::new_for_testing(document_token(1).page_id),
             ),
-            RendererOwnerWakeSender::signal_rendering_update_task,
+            RendererOwnerWakeSource::RenderingUpdateTask,
         );
         let route = source.route();
         Self {
@@ -1131,7 +1131,7 @@ impl MediaElementEventLane {
                 wake_tx,
                 RendererPageToken::new_for_testing(document_token(1).page_id),
             ),
-            RendererOwnerWakeSender::signal_media_element_event_task,
+            RendererOwnerWakeSource::MediaElementEventTask,
         );
         let route = source.route();
         Self {
@@ -1191,7 +1191,7 @@ impl UserInteractionLane {
                 wake_tx,
                 RendererPageToken::new_for_testing(document_token(1).page_id),
             ),
-            RendererOwnerWakeSender::signal_user_interaction_task,
+            RendererOwnerWakeSource::UserInteractionTask,
         );
         let route = source.route();
         Self {
@@ -1260,7 +1260,7 @@ impl FileReadingLane {
                 wake_tx,
                 RendererPageToken::new_for_testing(document_token(1).page_id),
             ),
-            RendererOwnerWakeSender::signal_file_reading_task,
+            RendererOwnerWakeSource::FileReadingTask,
         );
         let route = source.route();
         Self {
@@ -1320,7 +1320,7 @@ impl MiscPlatformApiLane {
                 wake_tx,
                 RendererPageToken::new_for_testing(document_token(1).page_id),
             ),
-            RendererOwnerWakeSender::signal_misc_platform_api_task,
+            RendererOwnerWakeSource::MiscPlatformApiTask,
         );
         let route = source.route();
         Self {

--- a/moli-renderer-v8/src/page_task_queue/ready_signal.rs
+++ b/moli-renderer-v8/src/page_task_queue/ready_signal.rs
@@ -1,0 +1,29 @@
+use moli_owner_queue::OwnerTaskReadySignal;
+
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource};
+
+/// Shared adapter from an owner-ready source edge to the Page owner wake lane.
+///
+/// Most Page task sources differ only in which typed admission hint they send.
+/// Keeping that choice as data avoids defining one signal type and trait
+/// implementation for every source while preserving the source-specific wake.
+#[derive(Clone, Debug)]
+pub(super) struct RendererPageTaskReadySignal {
+    owner_wake: RendererOwnerWakeSender,
+    source: RendererOwnerWakeSource,
+}
+
+impl RendererPageTaskReadySignal {
+    pub(super) fn new(
+        owner_wake: RendererOwnerWakeSender,
+        source: RendererOwnerWakeSource,
+    ) -> Self {
+        Self { owner_wake, source }
+    }
+}
+
+impl OwnerTaskReadySignal for RendererPageTaskReadySignal {
+    fn signal_ready(&self) {
+        self.owner_wake.signal_source(self.source);
+    }
+}

--- a/moli-renderer-v8/src/page_task_queue/rendering_update.rs
+++ b/moli-renderer-v8/src/page_task_queue/rendering_update.rs
@@ -9,7 +9,7 @@ use super::{
     },
 };
 #[cfg(test)]
-use super::{RendererOwnerWakeSender, WindowDocumentTaskTarget};
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, WindowDocumentTaskTarget};
 
 /// PageVm-local key for one pending Document rendering-update payload.
 ///
@@ -102,7 +102,7 @@ mod tests {
         );
         let mut source = RendererPageRenderingUpdateSource::new(
             owner_wake,
-            RendererOwnerWakeSender::signal_rendering_update_task,
+            RendererOwnerWakeSource::RenderingUpdateTask,
         );
         let sender = RendererPageRenderingUpdateSender::new(source.route(), root_document());
 
@@ -160,7 +160,7 @@ mod tests {
         );
         let source = RendererPageRenderingUpdateSource::new(
             owner_wake,
-            RendererOwnerWakeSender::signal_rendering_update_task,
+            RendererOwnerWakeSource::RenderingUpdateTask,
         );
         let sender = RendererPageRenderingUpdateSender::new(source.route(), root_document());
         drop(source);

--- a/moli-renderer-v8/src/page_task_queue/resource_completions.rs
+++ b/moli-renderer-v8/src/page_task_queue/resource_completions.rs
@@ -265,112 +265,20 @@ impl RendererOwnerWakeSender {
         self.signal_source(RendererOwnerWakeSource::ParseTimeDocumentScriptWork);
     }
 
-    pub(crate) fn signal_dom_manipulation_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::DomManipulationTask);
-    }
-
-    pub(crate) fn signal_user_interaction_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::UserInteractionTask);
-    }
-
-    pub(crate) fn signal_file_reading_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::FileReadingTask);
-    }
-
-    pub(crate) fn signal_misc_platform_api_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::MiscPlatformApiTask);
-    }
-
-    pub(crate) fn signal_navigation_and_traversal_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::NavigationAndTraversalTask);
-    }
-
-    pub(crate) fn signal_rendering_update_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::RenderingUpdateTask);
-    }
-
-    pub(crate) fn signal_media_element_event_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::MediaElementEventTask);
-    }
-
-    pub(crate) fn signal_dedicated_worker_client_event(&self) {
-        self.signal_source(RendererOwnerWakeSource::DedicatedWorkerClientEvent);
-    }
-
-    pub(crate) fn signal_shared_worker_client_event(&self) {
-        self.signal_source(RendererOwnerWakeSource::SharedWorkerClientEvent);
-    }
-
-    pub(crate) fn signal_service_worker_internal_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::ServiceWorkerInternalTask);
-    }
-
-    pub(crate) fn signal_service_worker_client_message(&self) {
-        self.signal_source(RendererOwnerWakeSource::ServiceWorkerClientMessage);
-    }
-
-    pub(crate) fn signal_webcrypto_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::WebCryptoTask);
-    }
-
     pub(crate) fn signal_indexed_db_task(&self) {
         self.signal_source(RendererOwnerWakeSource::IndexedDbTask);
-    }
-
-    pub(crate) fn signal_opfs_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::OpfsTask);
-    }
-
-    pub(crate) fn signal_internal_loading_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::InternalLoadingTask);
-    }
-
-    pub(crate) fn signal_main_document_runtime_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::MainDocumentRuntimeTask);
-    }
-
-    pub(crate) fn signal_child_module_dependency_fetch_start(&self) {
-        self.signal_source(RendererOwnerWakeSource::ChildModuleDependencyFetchStart);
-    }
-
-    pub(crate) fn signal_child_module_script_terminal(&self) {
-        self.signal_source(RendererOwnerWakeSource::ChildModuleScriptTerminal);
-    }
-
-    pub(crate) fn signal_child_modulepreload_event_action(&self) {
-        self.signal_source(RendererOwnerWakeSource::ChildModulepreloadEventAction);
     }
 
     pub(crate) fn signal_child_frame_task(&self) {
         self.signal_source(RendererOwnerWakeSource::ChildFrameTask);
     }
 
-    pub(crate) fn signal_v8_foreground_task(&self) {
-        self.signal_source(RendererOwnerWakeSource::V8ForegroundTask);
-    }
-
-    pub(crate) fn signal_module_reaction(&self) {
-        self.signal_source(RendererOwnerWakeSource::ModuleReaction);
-    }
-
     pub(crate) fn signal_window_message_task(&self) {
         self.signal_source(RendererOwnerWakeSource::WindowMessageTask);
     }
 
-    pub(crate) fn signal_message_port_delivery(&self) {
-        self.signal_source(RendererOwnerWakeSource::MessagePortDelivery);
-    }
-
     pub(crate) fn token(&self) -> RendererPageToken {
         self.token
-    }
-
-    pub(crate) fn signal_modulepreload_start(&self) {
-        self.signal_source(RendererOwnerWakeSource::ModulepreloadStart);
-    }
-
-    pub(crate) fn signal_dynamic_import_owner_action(&self) {
-        self.signal_source(RendererOwnerWakeSource::DynamicImportOwnerAction);
     }
 
     pub(crate) fn signal_document_lifecycle_turn(&self) {
@@ -411,7 +319,7 @@ impl RendererOwnerWakeSender {
         }
     }
 
-    fn signal_source(&self, source: RendererOwnerWakeSource) {
+    pub(super) fn signal_source(&self, source: RendererOwnerWakeSource) {
         let _ = self.tx.send(RendererOwnerWake::page(self.token, source));
     }
 }

--- a/moli-renderer-v8/src/page_task_queue/service_worker_client_message.rs
+++ b/moli-renderer-v8/src/page_task_queue/service_worker_client_message.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     resource_ready::{ReadyPageTask, RendererPageTaskReadyMetadata},
@@ -6,7 +6,7 @@ use crate::{
     types::{ServiceWorkerClientMessageCompletion, ServiceWorkerWindowClientTarget},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RendererPageServiceWorkerClientMessageOwner {
@@ -67,7 +67,7 @@ impl RendererPageServiceWorkerClientMessageTask {
 pub(crate) struct RendererPageServiceWorkerClientMessageRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageServiceWorkerClientMessageTask>,
-        RendererPageServiceWorkerClientMessageReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -94,7 +94,7 @@ impl RendererPageServiceWorkerClientMessageRoute {
 pub(crate) struct RendererPageServiceWorkerClientMessageSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageServiceWorkerClientMessageTask>,
-        RendererPageServiceWorkerClientMessageReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -115,31 +115,21 @@ impl RendererPageServiceWorkerClientMessageSender {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RendererPageServiceWorkerClientMessageRouteClosed;
 
-#[derive(Clone, Debug)]
-struct RendererPageServiceWorkerClientMessageReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageServiceWorkerClientMessageReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_service_worker_client_message();
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct RendererPageServiceWorkerClientMessageSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageServiceWorkerClientMessageTask>,
-        RendererPageServiceWorkerClientMessageReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageServiceWorkerClientMessageSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageServiceWorkerClientMessageReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::ServiceWorkerClientMessage,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/service_worker_internal.rs
+++ b/moli-renderer-v8/src/page_task_queue/service_worker_internal.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     resource_ready::{ReadyPageTask, RendererPageTaskReadyMetadata},
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Browser-context ServiceWorker callback delivered to one exact PageVm.
 ///
@@ -100,7 +100,7 @@ impl RendererPageServiceWorkerInternalTask {
 pub(crate) struct RendererPageServiceWorkerInternalRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageServiceWorkerInternalTask>,
-        RendererPageServiceWorkerInternalReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -124,7 +124,7 @@ impl RendererPageServiceWorkerInternalRoute {
 pub(crate) struct RendererPageServiceWorkerInternalSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageServiceWorkerInternalTask>,
-        RendererPageServiceWorkerInternalReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -145,31 +145,21 @@ impl RendererPageServiceWorkerInternalSender {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RendererPageServiceWorkerInternalRouteClosed;
 
-#[derive(Clone, Debug)]
-struct RendererPageServiceWorkerInternalReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageServiceWorkerInternalReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_service_worker_internal_task();
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct RendererPageServiceWorkerInternalSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageServiceWorkerInternalTask>,
-        RendererPageServiceWorkerInternalReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageServiceWorkerInternalSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageServiceWorkerInternalReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::ServiceWorkerInternalTask,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/shared_worker_client_event.rs
+++ b/moli-renderer-v8/src/page_task_queue/shared_worker_client_event.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 use moli_shared_worker::SharedWorkerClientId;
 
 use crate::{
@@ -8,7 +8,7 @@ use crate::{
     shared_worker_runtime::{SharedWorkerClientEndpointDisposition, SharedWorkerClientEvent},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Exact Page-side SharedWorker wrapper that owns one client event.
 ///
@@ -99,7 +99,7 @@ pub(crate) struct RendererPageSharedWorkerClientEventRouteClosed;
 pub(crate) struct RendererPageSharedWorkerClientEventRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageSharedWorkerClientEventTask>,
-        RendererPageSharedWorkerClientEventReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -125,7 +125,7 @@ impl RendererPageSharedWorkerClientEventRoute {
 pub(crate) struct RendererPageSharedWorkerClientEventSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageSharedWorkerClientEventTask>,
-        RendererPageSharedWorkerClientEventReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
 }
@@ -149,7 +149,7 @@ impl RendererPageSharedWorkerClientEventSender {
 pub(crate) struct RendererPageSharedWorkerClientEventRealmSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageSharedWorkerClientEventTask>,
-        RendererPageSharedWorkerClientEventReadySignal,
+        RendererPageTaskReadySignal,
     >,
     root_document: RendererDocumentToken,
     execution_context: WindowExecutionContextIdentity,
@@ -176,7 +176,7 @@ impl RendererPageSharedWorkerClientEventRealmSender {
 pub(crate) struct RendererPageSharedWorkerClientEventProducer {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageSharedWorkerClientEventTask>,
-        RendererPageSharedWorkerClientEventReadySignal,
+        RendererPageTaskReadySignal,
     >,
     owner: RendererPageSharedWorkerClientEventOwner,
 }
@@ -194,32 +194,22 @@ impl RendererPageSharedWorkerClientEventProducer {
     }
 }
 
-#[derive(Clone, Debug)]
-struct RendererPageSharedWorkerClientEventReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageSharedWorkerClientEventReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_shared_worker_client_event();
-    }
-}
-
 /// Unique Page-lifetime consumer for SharedWorker client events.
 #[derive(Debug)]
 pub(crate) struct RendererPageSharedWorkerClientEventSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageSharedWorkerClientEventTask>,
-        RendererPageSharedWorkerClientEventReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl RendererPageSharedWorkerClientEventSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageSharedWorkerClientEventReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::SharedWorkerClientEvent,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/v8_foreground_task.rs
+++ b/moli-renderer-v8/src/page_task_queue/v8_foreground_task.rs
@@ -1,11 +1,11 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     resource_ready::{ReadyPageTask, RendererPageTaskReadyMetadata},
     runtime::{PageOwnerTurnOutcome, RendererPageToken},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// Stable Page owner of a V8 foreground task.
 ///
@@ -56,7 +56,7 @@ pub(crate) struct RendererPageV8ForegroundTaskRouteClosed;
 pub(crate) struct RendererPageV8ForegroundTaskSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageV8ForegroundTask>,
-        RendererPageV8ForegroundTaskReadySignal,
+        RendererPageTaskReadySignal,
     >,
     owner: RendererPageV8ForegroundTaskOwner,
 }
@@ -78,23 +78,12 @@ impl RendererPageV8ForegroundTaskSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct RendererPageV8ForegroundTaskReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageV8ForegroundTaskReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_v8_foreground_task();
-    }
-}
-
 /// Unique Page-lifetime consumer for V8 foreground continuations.
 #[derive(Debug)]
 pub(crate) struct RendererPageV8ForegroundTaskSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageV8ForegroundTask>,
-        RendererPageV8ForegroundTaskReadySignal,
+        RendererPageTaskReadySignal,
     >,
     owner: RendererPageV8ForegroundTaskOwner,
 }
@@ -103,9 +92,10 @@ impl RendererPageV8ForegroundTaskSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         let owner = RendererPageV8ForegroundTaskOwner::new(owner_wake.token());
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageV8ForegroundTaskReadySignal {
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
                 owner_wake,
-            }),
+                RendererOwnerWakeSource::V8ForegroundTask,
+            )),
             owner,
         }
     }

--- a/moli-renderer-v8/src/page_task_queue/webcrypto_task.rs
+++ b/moli-renderer-v8/src/page_task_queue/webcrypto_task.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     context_bootstrap::{WebCryptoRejection, WebCryptoTaskResult},
@@ -7,7 +7,7 @@ use crate::{
     runtime::{PageOwnerTurnOutcome, RendererDocumentToken},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// PageVm-local identity of one pending WebCrypto Promise.
 ///
@@ -107,10 +107,8 @@ pub(crate) struct RendererPageWebCryptoTaskRouteClosed;
 
 #[derive(Clone, Debug)]
 pub(crate) struct RendererPageWebCryptoTaskRoute {
-    task_route: OwnerReadyTaskRoute<
-        ReadyPageTask<RendererPageWebCryptoTask>,
-        RendererPageWebCryptoTaskReadySignal,
-    >,
+    task_route:
+        OwnerReadyTaskRoute<ReadyPageTask<RendererPageWebCryptoTask>, RendererPageTaskReadySignal>,
 }
 
 impl RendererPageWebCryptoTaskRoute {
@@ -132,10 +130,8 @@ impl RendererPageWebCryptoTaskRoute {
 /// PageVm-stamped route used only while a WebCrypto Promise is registered.
 #[derive(Clone, Debug)]
 pub(crate) struct RendererPageWebCryptoTaskSender {
-    task_route: OwnerReadyTaskRoute<
-        ReadyPageTask<RendererPageWebCryptoTask>,
-        RendererPageWebCryptoTaskReadySignal,
-    >,
+    task_route:
+        OwnerReadyTaskRoute<ReadyPageTask<RendererPageWebCryptoTask>, RendererPageTaskReadySignal>,
     root_document: RendererDocumentToken,
 }
 
@@ -158,10 +154,8 @@ impl RendererPageWebCryptoTaskSender {
 /// rebuilding the exact task at registration time.
 #[derive(Debug)]
 pub(crate) struct RendererPageWebCryptoTaskProducer {
-    task_route: OwnerReadyTaskRoute<
-        ReadyPageTask<RendererPageWebCryptoTask>,
-        RendererPageWebCryptoTaskReadySignal,
-    >,
+    task_route:
+        OwnerReadyTaskRoute<ReadyPageTask<RendererPageWebCryptoTask>, RendererPageTaskReadySignal>,
     owner: RendererPageWebCryptoTaskOwner,
 }
 
@@ -183,30 +177,20 @@ impl RendererPageWebCryptoTaskProducer {
     }
 }
 
-#[derive(Clone, Debug)]
-struct RendererPageWebCryptoTaskReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageWebCryptoTaskReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_webcrypto_task();
-    }
-}
-
 /// Unique Page-lifetime consumer for completed WebCrypto operations.
 #[derive(Debug)]
 pub(crate) struct RendererPageWebCryptoTaskSource {
-    source: OwnerReadyTaskSource<
-        ReadyPageTask<RendererPageWebCryptoTask>,
-        RendererPageWebCryptoTaskReadySignal,
-    >,
+    source:
+        OwnerReadyTaskSource<ReadyPageTask<RendererPageWebCryptoTask>, RendererPageTaskReadySignal>,
 }
 
 impl RendererPageWebCryptoTaskSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageWebCryptoTaskReadySignal { owner_wake }),
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
+                owner_wake,
+                RendererOwnerWakeSource::WebCryptoTask,
+            )),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/window_document_task_source.rs
+++ b/moli-renderer-v8/src/page_task_queue/window_document_task_source.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     native_bridge::WindowDocumentTaskTarget,
@@ -7,22 +7,9 @@ use crate::{
 };
 
 use super::{
-    RendererOwnerWakeSender, RendererPageWindowDocumentTask, RendererPageWindowDocumentTaskOwner,
+    RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal,
+    RendererPageWindowDocumentTask, RendererPageWindowDocumentTaskOwner,
 };
-
-type ReadySignalFn = fn(&RendererOwnerWakeSender);
-
-#[derive(Clone, Debug)]
-struct RendererPageWindowDocumentTaskReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-    signal: ReadySignalFn,
-}
-
-impl OwnerTaskReadySignal for RendererPageWindowDocumentTaskReadySignal {
-    fn signal_ready(&self) {
-        (self.signal)(&self.owner_wake);
-    }
-}
 
 /// Shared route for task-source families whose stable queue only needs an
 /// exact Window/Document owner, a Host-local payload id, and a family-local
@@ -35,7 +22,7 @@ impl OwnerTaskReadySignal for RendererPageWindowDocumentTaskReadySignal {
 pub(crate) struct RendererPageWindowDocumentTaskRoute<I, K> {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageWindowDocumentTask<I, K>>,
-        RendererPageWindowDocumentTaskReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
@@ -103,17 +90,17 @@ impl<I: Copy, K: Copy> RendererPageWindowDocumentTaskSender<I, K> {
 pub(crate) struct RendererPageWindowDocumentTaskSource<I, K> {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageWindowDocumentTask<I, K>>,
-        RendererPageWindowDocumentTaskReadySignal,
+        RendererPageTaskReadySignal,
     >,
 }
 
 impl<I: Copy, K: Copy> RendererPageWindowDocumentTaskSource<I, K> {
-    pub(crate) fn new(owner_wake: RendererOwnerWakeSender, signal: ReadySignalFn) -> Self {
+    pub(crate) fn new(
+        owner_wake: RendererOwnerWakeSender,
+        source: RendererOwnerWakeSource,
+    ) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageWindowDocumentTaskReadySignal {
-                owner_wake,
-                signal,
-            }),
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(owner_wake, source)),
         }
     }
 

--- a/moli-renderer-v8/src/page_task_queue/window_message.rs
+++ b/moli-renderer-v8/src/page_task_queue/window_message.rs
@@ -1,4 +1,4 @@
-use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource, OwnerTaskReadySignal};
+use moli_owner_queue::{OwnerReadyTaskRoute, OwnerReadyTaskSource};
 
 use crate::{
     native_bridge::WindowTaskTarget,
@@ -6,7 +6,7 @@ use crate::{
     runtime::{PageOwnerTurnOutcome, RendererDocumentToken},
 };
 
-use super::RendererOwnerWakeSender;
+use super::{RendererOwnerWakeSender, RendererOwnerWakeSource, RendererPageTaskReadySignal};
 
 /// PageVm-local key for a structured-clone payload retained by JsContextHost.
 ///
@@ -93,7 +93,7 @@ pub(crate) struct RendererPageWindowMessageRouteClosed;
 pub(crate) struct RendererPageWindowMessageRoute {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageWindowMessageTask>,
-        RendererPageWindowMessageReadySignal,
+        RendererPageTaskReadySignal,
     >,
     owner_wake: RendererOwnerWakeSender,
 }
@@ -120,7 +120,7 @@ impl RendererPageWindowMessageRoute {
 pub(crate) struct RendererPageWindowMessageSender {
     task_route: OwnerReadyTaskRoute<
         ReadyPageTask<RendererPageWindowMessageTask>,
-        RendererPageWindowMessageReadySignal,
+        RendererPageTaskReadySignal,
     >,
     owner_wake: RendererOwnerWakeSender,
     root_document: RendererDocumentToken,
@@ -149,17 +149,6 @@ impl RendererPageWindowMessageSender {
     }
 }
 
-#[derive(Clone, Debug)]
-struct RendererPageWindowMessageReadySignal {
-    owner_wake: RendererOwnerWakeSender,
-}
-
-impl OwnerTaskReadySignal for RendererPageWindowMessageReadySignal {
-    fn signal_ready(&self) {
-        self.owner_wake.signal_window_message_task();
-    }
-}
-
 /// Unique Page-lifetime consumer for Window.postMessage tasks.
 ///
 /// This is one FIFO posted-message task source for the Page. A current
@@ -171,7 +160,7 @@ impl OwnerTaskReadySignal for RendererPageWindowMessageReadySignal {
 pub(crate) struct RendererPageWindowMessageSource {
     source: OwnerReadyTaskSource<
         ReadyPageTask<RendererPageWindowMessageTask>,
-        RendererPageWindowMessageReadySignal,
+        RendererPageTaskReadySignal,
     >,
     owner_wake: RendererOwnerWakeSender,
 }
@@ -179,9 +168,10 @@ pub(crate) struct RendererPageWindowMessageSource {
 impl RendererPageWindowMessageSource {
     pub(crate) fn new(owner_wake: RendererOwnerWakeSender) -> Self {
         Self {
-            source: OwnerReadyTaskSource::new(RendererPageWindowMessageReadySignal {
-                owner_wake: owner_wake.clone(),
-            }),
+            source: OwnerReadyTaskSource::new(RendererPageTaskReadySignal::new(
+                owner_wake.clone(),
+                RendererOwnerWakeSource::WindowMessageTask,
+            )),
             owner_wake,
         }
     }


### PR DESCRIPTION
Replace each owner-ready source's general two-channel OwnerTaskSource plus separate readiness and signal allocations with one shared incoming queue/state and one owner-local accepted queue.\n\nPreserve close errors, route identity, FIFO batch admission, edge-triggered wakeups, and drop payloads outside the shared lock. The general OwnerTaskSource remains available for parser-boundary users that need its distinct semantics.