### PR TITLE
perf(dom): avoid materializing empty nonce state

### DIFF
--- a/moli-dom/src/native/element/mod.rs
+++ b/moli-dom/src/native/element/mod.rs
@@ -933,6 +933,9 @@ impl Element {
     }
 
     pub fn set_cryptographic_nonce(&mut self, nonce: Option<String>) -> bool {
+        if self.cryptographic_nonce() == nonce.as_deref() {
+            return false;
+        }
         self.control_state_mut().set_cryptographic_nonce(nonce)
     }
 

--- a/moli-dom/src/native/element/tests.rs
+++ b/moli-dom/src/native/element/tests.rs
@@ -13,6 +13,7 @@ fn ordinary_elements_keep_control_state_unmaterialized_until_needed() {
     assert_eq!(div.scroll_top(), 0.0);
     assert!(!div.set_scroll_top(0.0));
     assert!(!div.set_scroll_left(0.0));
+    assert!(!div.set_cryptographic_nonce(None));
     assert!(!div.popover_open());
     assert!(div.custom_states().is_empty());
     assert!(!div.rare_data.is_materialized());


### PR DESCRIPTION
## Summary

- Keep element nonce state unmaterialized until nonce-specific state is actually needed.
- Cover the default empty representation with a regression assertion.

This removes avoidable per-element state from ordinary DOM nodes.

## Validation

The original combined branch passed workspace fmt, clippy with warnings denied, and all 16,917 nextest tests. This branch is an isolated cherry-pick onto the latest main.