### PR TITLE
build: use one codegen unit for release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,9 @@ panic = "abort"
 [profile.release]
 panic = "abort"
 strip = false
+# Production and release-regression binaries favor a compact code working set
+# over parallel code generation.
+codegen-units = 1
 
 [profile.test]
 debug = 1

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -31,6 +31,11 @@ signed. The allocator behind the default `jemalloc` feature is target-gated
 out on Windows, so Windows builds use the system allocator because upstream
 treats the Windows/MSVC combination as untested.
 
+Release builds use one code-generation unit. The release workflow and the CI
+release-regression binaries both invoke Cargo with `--release`, so they consume
+the same production profile. Normal development and unit-test builds retain
+their separate profiles and parallel code generation.
+
 ## Prepare the release
 
 1. Update `version` in `moli/Cargo.toml` and refresh `Cargo.lock`.


### PR DESCRIPTION
## Summary

- compile the Cargo `release` profile with one code-generation unit
- keep LTO explicitly disabled because both Thin and Fat LTO increased the measured resident code footprint
- document that GitHub Release artifacts and CI release-regression binaries share this profile through `--release`
- leave normal development and unit-test profiles unchanged

## Why

The memory investigation found that `codegen-units=1` reduced DCL PSS by 8.564 MiB and resident executable pages by 7.746 MiB versus the default 16-CGU release build, with all 10 paired runs improving. The DOM hot-path gate did not show a throughput tradeoff. Thin/Fat LTO and machine outlining did not pass the same runtime gates, so this PR intentionally enables none of them.

Both production packaging (`scripts/release.py`) and the CI HEAD/base binaries consumed by release-regression, WebFetch, CDP, and frontend tests already invoke Cargo with `--release`. Keeping the setting in the release profile gives those paths one source of truth.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --no-fail-fast` — 16,907 passed, 13 skipped
- `cargo build --release --locked -p moli -vv` — completed in 4m24s; 80 emitted rustc commands contained `-C codegen-units=1`, and none contained an LTO flag
- `target/release/moli --version` — `moli 1.0.6`
