### PR TITLE
fix(fetch): order requestPaused after the Runtime command response

### DIFF
--- a/moli-protocol-server/src/cdp_scheduler.rs
+++ b/moli-protocol-server/src/cdp_scheduler.rs
@@ -831,10 +831,17 @@ impl CdpScheduler {
         // must use that exact id rather than infer one from the frontend CDP
         // request id.
         let runtime_output_barrier = if command.runtime_command_executes_page_javascript() {
+            let awaiting = command.request().params().is_some_and(|params| {
+                params
+                    .get("awaitPromise")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false)
+            }) || command.request().method() == "Runtime.awaitPromise";
             self.runtime_command_output_barriers.admit(
                 &self.conn,
                 command.request().id(),
                 command.command_output_session_id(),
+                awaiting,
             )
         } else {
             None

--- a/moli-protocol-server/src/protocol_server/tests/websocket.rs
+++ b/moli-protocol-server/src/protocol_server/tests/websocket.rs
@@ -5108,6 +5108,138 @@ async fn websocket_cdp_runtime_call_function_awaitpromise_fetch_interception_unb
 }
 
 #[tokio::test]
+async fn websocket_cdp_runtime_evaluate_fetch_interception_orders_pause_after_response() {
+    async fn page() -> impl IntoResponse {
+        (
+            [(axum::http::header::CONTENT_TYPE.as_str(), "text/html")],
+            "<!doctype html><html><body>ready</body></html>",
+        )
+    }
+
+    async fn api() -> impl IntoResponse {
+        "api body"
+    }
+
+    let fixture_app = Router::new()
+        .route("/page", get(page))
+        .route("/api", get(api));
+    let (fixture_addr, _fixture_server) =
+        spawn_dedicated_fixture_server(fixture_app, "runtime-evaluate-fetch-ordering");
+
+    let (cdp_addr, protocol_server) = spawn_test_protocol_server().await;
+    let (mut socket, _) = connect_async(format!(
+        "ws://{cdp_addr}/devtools/browser/{DEFAULT_BROWSER_ID}"
+    ))
+    .await
+    .expect("connect to cdp websocket");
+    let page_url = format!("http://{fixture_addr}/page");
+    let session_id = cdp_create_session_and_navigate(&mut socket, &page_url).await;
+
+    let _ = send_cdp_command(
+        &mut socket,
+        6,
+        "Fetch.enable",
+        Some(&session_id),
+        json!({
+            "patterns": [{
+                "urlPattern": "*",
+                "requestStage": "Request"
+            }]
+        }),
+    )
+    .await;
+
+    // A non-awaiting Runtime.evaluate triggers the subresource fetch. Chromium
+    // delivers `Fetch.requestPaused` only after the evaluate response, so a
+    // client that awaits the response before listening must still observe the
+    // pause.
+    socket
+        .send(WsMessage::Text(
+            json!({
+                "id": 7_u64,
+                "method": "Runtime.evaluate",
+                "sessionId": session_id,
+                "params": {
+                    "expression": "fetch('/api').then(r => { window.__r = r.status }).catch(e => { window.__er = e.name }); 'scheduled'",
+                    "returnByValue": true
+                }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send non-awaiting evaluate fetch");
+
+    let pause_messages = recv_until_match(&mut socket, |message| {
+        message["sessionId"].as_str() == Some(session_id.as_str())
+            && message["method"] == json!("Fetch.requestPaused")
+    })
+    .await;
+    let response_index = pause_messages
+        .iter()
+        .position(|message| message["id"] == json!(7_u64))
+        .unwrap_or_else(|| panic!("expected evaluate response: {pause_messages:?}"));
+    let pause_index = pause_messages
+        .iter()
+        .position(|message| message["method"] == json!("Fetch.requestPaused"))
+        .expect("requestPaused observed");
+    assert!(
+        response_index < pause_index,
+        "Fetch.requestPaused must follow the evaluate response: {pause_messages:?}"
+    );
+
+    let request_id = pause_messages
+        .iter()
+        .find(|message| message["method"] == json!("Fetch.requestPaused"))
+        .and_then(|message| message["params"]["requestId"].as_str())
+        .expect("requestPaused requestId")
+        .to_owned();
+    let _ = send_cdp_command(
+        &mut socket,
+        8,
+        "Fetch.continueRequest",
+        Some(&session_id),
+        json!({ "requestId": request_id }),
+    )
+    .await;
+
+    let resolved = {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let result = send_cdp_command(
+                &mut socket,
+                9,
+                "Runtime.evaluate",
+                Some(&session_id),
+                json!({
+                    "expression": "window.__r === 200 ? 'done' : 'pending'",
+                    "returnByValue": true
+                }),
+            )
+            .await;
+            let value = result
+                .iter()
+                .find(|message| message["id"] == json!(9_u64))
+                .and_then(|message| message["result"]["result"]["value"].as_str())
+                .unwrap_or_default()
+                .to_owned();
+            if value == "done" {
+                break value;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "continued fetch should resolve with status 200"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    };
+    assert_eq!(resolved, "done");
+
+    let _ = socket.close(None).await;
+    protocol_server.abort();
+}
+
+#[tokio::test]
 async fn websocket_cdp_fetch_routes_pending_background_parser_script_to_exact_session() {
     async fn page() -> impl IntoResponse {
         (

--- a/moli-protocol/src/domains/activity/output_ingress/prepared_outputs.rs
+++ b/moli-protocol/src/domains/activity/output_ingress/prepared_outputs.rs
@@ -496,11 +496,24 @@ impl PreparedProtocolOutputs {
         conn: &mut CdpConnection,
         session_id: Option<&str>,
         command_context: &mut CommandDispatchContext,
+        defer_fetch_pause_after_response: bool,
     ) -> Option<Self> {
         let mut before_response = Vec::new();
         let mut after_response = Vec::new();
         for slot in std::mem::take(&mut self.ordered_slots) {
-            match slot.command_response_order() {
+            let order = slot.command_response_order();
+            let order = if defer_fetch_pause_after_response
+                && slot == ProtocolOutputSlot::SubresourceFetchInterception
+            {
+                // Chromium pauses a subresource Fetch request only after the
+                // invoking Runtime command has returned. Defer the pause for a
+                // non-awaiting command so a client that awaits the evaluate
+                // response still observes `Fetch.requestPaused` afterwards.
+                ProtocolOutputResponseOrder::AfterResponse
+            } else {
+                order
+            };
+            match order {
                 ProtocolOutputResponseOrder::BeforeResponse => before_response.push(slot),
                 ProtocolOutputResponseOrder::AfterResponse => after_response.push(slot),
             }

--- a/moli-protocol/src/domains/activity/runtime_command_barrier.rs
+++ b/moli-protocol/src/domains/activity/runtime_command_barrier.rs
@@ -67,6 +67,7 @@ struct ActiveRuntimeCommandOutputBarrier {
     command_scope: CommandOwnerScope,
     causal_owner: RuntimeCommandCausalOwner,
     renderer_cause: RendererRuntimeCommandCausalIdentity,
+    awaiting: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -187,6 +188,7 @@ impl RuntimeCommandOutputBarriers {
         conn: &CdpConnection,
         command_id: u64,
         session_id: Option<&str>,
+        awaiting: bool,
     ) -> Option<RuntimeCommandOutputBarrierPermit> {
         let command_scope = CommandOwnerScope::capture(conn, session_id);
         let causal_owner = RuntimeCommandCausalOwner::capture(conn, session_id)?;
@@ -211,6 +213,7 @@ impl RuntimeCommandOutputBarriers {
                 command_scope,
                 causal_owner,
                 renderer_cause,
+                awaiting,
             },
         );
         assert!(
@@ -296,8 +299,17 @@ impl RuntimeCommandOutputBarriers {
         outputs: PreparedProtocolOutputs,
         command_context: &mut CommandDispatchContext,
     ) {
+        let awaiting = self
+            .active
+            .get(&barrier_id)
+            .is_some_and(|barrier| barrier.awaiting);
         let Some(outputs) = outputs
-            .project_before_command_response_and_hold_after(conn, session_id, command_context)
+            .project_before_command_response_and_hold_after(
+                conn,
+                session_id,
+                command_context,
+                !awaiting,
+            )
             .await
         else {
             return;
@@ -558,7 +570,7 @@ mod tests {
         )
         .expect("test Runtime command should register its renderer call");
         barriers
-            .admit(conn, frontend_command_id, Some(SESSION_ID))
+            .admit(conn, frontend_command_id, Some(SESSION_ID), false)
             .expect("registered Runtime command should admit an exact output barrier")
     }
 

--- a/moli-protocol/src/testing.rs
+++ b/moli-protocol/src/testing.rs
@@ -774,10 +774,17 @@ impl TestContext {
         command
             .runtime_command_executes_page_javascript()
             .then(|| {
+                let awaiting = command.request().params().is_some_and(|params| {
+                    params
+                        .get("awaitPromise")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(false)
+                }) || command.request().method() == "Runtime.awaitPromise";
                 self.runtime_command_output_barriers.admit(
                     &self.conn,
                     command.request().id(),
                     command.command_output_session_id(),
+                    awaiting,
                 )
             })
             .flatten()


### PR DESCRIPTION
Moli delivered `Fetch.requestPaused` before the `Runtime.evaluate`
response that triggered the subresource fetch, while Chromium delivers
it after. A CDP client that awaits the evaluate response before
listening for the pause therefore consumed the event and never saw it,
leaving the matching in-page fetch() paused forever.

Defer the subresource-fetch-pause output until after the response for
non-awaiting Runtime commands (evaluate/callFunctionOn without
awaitPromise), so the pause is observed after the command returns like
Chromium. Awaiting commands keep the pause before the response so it is
delivered while the promise is pending, avoiding a deadlock where the
awaited promise can only settle after the client continues the request.

Adds a protocol-server regression test asserting requestPaused follows
the evaluate response and that Fetch.continueRequest resolves the
fetch with the real status.