### PR TITLE
ci: export Moli stargazer profiles

### DIFF
--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -39,101 +39,104 @@ jobs:
           from datetime import datetime, timezone
 
           token = os.environ["STARGAZER_TOKEN"]
-          query = """
-          query($owner: String!, $name: String!, $cursor: String) {
-            repository(owner: $owner, name: $name) {
-              stargazers(
-                first: 100
-                after: $cursor
-                orderBy: {field: STARRED_AT, direction: DESC}
-              ) {
-                totalCount
-                pageInfo { hasNextPage endCursor }
-                edges {
-                  starredAt
-                  node {
-                    login
-                    name
-                    url
-                    company
-                    location
-                    bio
-                    websiteUrl
-                    twitterUsername
-                    repositories { totalCount }
-                    followers { totalCount }
-                    following { totalCount }
-                    isHireable
-                    createdAt
-                    updatedAt
-                  }
-                }
-              }
-            }
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+              "User-Agent": "lexmount-moli-stargazer-export",
           }
-          """
 
-          def graphql(variables, attempts=6):
-              payload = json.dumps({"query": query, "variables": variables}).encode()
+          def request_json(url, data=None, attempts=6, extra_headers=None):
+              request_headers = dict(headers)
+              if extra_headers:
+                  request_headers.update(extra_headers)
               request = urllib.request.Request(
-                  "https://api.github.com/graphql",
-                  data=payload,
-                  method="POST",
-                  headers={
-                      "Accept": "application/vnd.github+json",
-                      "Authorization": f"Bearer {token}",
-                      "Content-Type": "application/json",
-                      "User-Agent": "lexmount-moli-stargazer-export",
-                  },
+                  url,
+                  data=data,
+                  method="POST" if data is not None else "GET",
+                  headers=request_headers,
               )
               for attempt in range(attempts):
                   try:
                       with urllib.request.urlopen(request, timeout=60) as response:
-                          result = json.load(response)
-                      if result.get("errors"):
-                          raise RuntimeError(json.dumps(result["errors"], ensure_ascii=False))
-                      return result["data"]
+                          return json.load(response)
                   except (urllib.error.URLError, TimeoutError):
                       if attempt == attempts - 1:
                           raise
                       time.sleep(min(2 ** attempt, 30))
-              raise RuntimeError("GraphQL request failed after retries")
+              raise RuntimeError(f"Request failed after retries: {url}")
+
+          stargazers = []
+          page = 1
+          while True:
+              url = f"https://api.github.com/repos/lexmount/moli/stargazers?per_page=100&page={page}"
+              batch = request_json(
+                  url,
+                  extra_headers={"Accept": "application/vnd.github.star+json"},
+              )
+              if not batch:
+                  break
+              stargazers.extend(batch)
+              print(f"Fetched stargazer page {page}: {len(batch)} users")
+              if len(batch) < 100:
+                  break
+              page += 1
+
+          profile_fields = """
+            login name url company location bio websiteUrl twitterUsername
+            repositories { totalCount }
+            followers { totalCount }
+            following { totalCount }
+            isHireable createdAt updatedAt
+          """
+
+          profiles_by_login = {}
+          logins = [item["user"]["login"] for item in stargazers if item.get("user")]
+          for start in range(0, len(logins), 50):
+              chunk = logins[start:start + 50]
+              aliases = []
+              for index, login in enumerate(chunk):
+                  aliases.append(
+                      f'u{index}: user(login: {json.dumps(login)}) {{ {profile_fields} }}'
+                  )
+              query = "query { " + " ".join(aliases) + " }"
+              payload = json.dumps({"query": query}).encode()
+              result = request_json(
+                  "https://api.github.com/graphql",
+                  data=payload,
+                  extra_headers={"Content-Type": "application/json"},
+              )
+              if result.get("errors"):
+                  print("GraphQL partial errors:", json.dumps(result["errors"], ensure_ascii=False))
+              data = result.get("data") or {}
+              for index, login in enumerate(chunk):
+                  profiles_by_login[login] = data.get(f"u{index}")
+              print(f"Enriched {min(start + len(chunk), len(logins))}/{len(logins)} profiles")
 
           rows = []
-          cursor = None
-          expected_total = None
-          page = 0
-          while True:
-              page += 1
-              data = graphql({"owner": "lexmount", "name": "moli", "cursor": cursor})
-              connection = data["repository"]["stargazers"]
-              expected_total = connection["totalCount"]
-              for edge in connection["edges"]:
-                  user = edge["node"]
-                  rows.append({
-                      "login": user.get("login"),
-                      "name": user.get("name"),
-                      "starred_at": edge.get("starredAt"),
-                      "profile_url": user.get("url"),
-                      "account_type": "User",
-                      "company": user.get("company"),
-                      "location": user.get("location"),
-                      "bio": user.get("bio"),
-                      "blog": user.get("websiteUrl"),
-                      "twitter_username": user.get("twitterUsername"),
-                      "public_repos": (user.get("repositories") or {}).get("totalCount"),
-                      "followers": (user.get("followers") or {}).get("totalCount"),
-                      "following": (user.get("following") or {}).get("totalCount"),
-                      "hireable": user.get("isHireable"),
-                      "account_created_at": user.get("createdAt"),
-                      "account_updated_at": user.get("updatedAt"),
-                      "profile_error": None,
-                  })
-              print(f"Fetched page {page}: {len(connection['edges'])} users; total {len(rows)}/{expected_total}")
-              page_info = connection["pageInfo"]
-              if not page_info["hasNextPage"]:
-                  break
-              cursor = page_info["endCursor"]
+          for item in stargazers:
+              user_stub = item.get("user") or {}
+              login = user_stub.get("login")
+              user = profiles_by_login.get(login) or {}
+              rows.append({
+                  "login": login,
+                  "name": user.get("name"),
+                  "starred_at": item.get("starred_at"),
+                  "profile_url": user.get("url") or user_stub.get("html_url"),
+                  "account_type": user_stub.get("type"),
+                  "company": user.get("company"),
+                  "location": user.get("location"),
+                  "bio": user.get("bio"),
+                  "blog": user.get("websiteUrl"),
+                  "twitter_username": user.get("twitterUsername"),
+                  "public_repos": (user.get("repositories") or {}).get("totalCount"),
+                  "followers": (user.get("followers") or {}).get("totalCount"),
+                  "following": (user.get("following") or {}).get("totalCount"),
+                  "hireable": user.get("isHireable"),
+                  "account_created_at": user.get("createdAt"),
+                  "account_updated_at": user.get("updatedAt"),
+                  "profile_error": None if user else "profile_unavailable",
+              })
 
           fields = [
               "login", "name", "starred_at", "profile_url", "account_type",
@@ -146,26 +149,24 @@ jobs:
               writer.writeheader()
               writer.writerows(rows)
 
+          error_count = sum(bool(row["profile_error"]) for row in rows)
           output = {
               "repository": "lexmount/moli",
               "exported_at": datetime.now(timezone.utc).isoformat(),
-              "stargazer_count": expected_total,
+              "stargazer_count": len(stargazers),
               "profile_count": len(rows),
-              "profile_error_count": 0,
+              "profile_error_count": error_count,
               "fields": fields,
               "profiles": rows,
           }
           with open("moli-stargazers.json", "w", encoding="utf-8") as handle:
               json.dump(output, handle, ensure_ascii=False, indent=2)
 
-          if len(rows) != expected_total:
-              raise RuntimeError(f"Count mismatch: fetched {len(rows)}, expected {expected_total}")
-
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
               handle.write("## Moli stargazer export\n\n")
-              handle.write(f"- Stargazers: {expected_total}\n")
+              handle.write(f"- Stargazers: {len(stargazers)}\n")
               handle.write(f"- Profiles: {len(rows)}\n")
-              handle.write("- Profile errors: 0\n")
+              handle.write(f"- Profile errors: {error_count}\n")
           PY
 
       - name: Upload export

--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -1,5 +1,9 @@
 name: Export Moli community interactions
 
+concurrency:
+  group: moli-community-export
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches: [main]
@@ -114,14 +118,6 @@ jobs:
 
           pr_reviews = []
           pr_review_comments = []
-          for pull in pulls:
-              number = pull["number"]
-              for review in paginate(f"{api}/pulls/{number}/reviews?"):
-                  review["_pull_number"] = number
-                  pr_reviews.append(review)
-              for comment in paginate(f"{api}/pulls/{number}/comments?"):
-                  comment["_pull_number"] = number
-                  pr_review_comments.append(comment)
 
           def login_of(value):
               if not value:

--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -101,6 +101,16 @@ jobs:
                       time.sleep(min(2 ** attempt, 30))
               raise RuntimeError(f"Request failed after retries: {url}")
 
+          viewer = request_json("https://api.github.com/user")
+          repository = request_json("https://api.github.com/repos/lexmount/moli")
+          print("Token diagnostics:", json.dumps({
+              "login": viewer.get("login"),
+              "token_type": viewer.get("type"),
+              "repository_full_name": repository.get("full_name"),
+              "repository_visibility": repository.get("visibility"),
+              "repository_permissions": repository.get("permissions"),
+          }, ensure_ascii=False))
+
           stargazers = []
           page = 1
           while True:

--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -1,0 +1,185 @@
+name: Export Moli stargazers
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/export-moli-stargazers.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    if: github.head_ref == 'codex/export-moli-stargazers'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      STARGAZER_TOKEN: ${{ secrets.GH_TOKEN }}
+
+    steps:
+      - name: Verify token is configured
+        shell: bash
+        run: |
+          if [ -z "$STARGAZER_TOKEN" ]; then
+            echo "::error::Repository secret GH_TOKEN is not configured or unavailable."
+            exit 1
+          fi
+
+      - name: Export public stargazer profiles
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import csv
+          import json
+          import os
+          import random
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+          from concurrent.futures import ThreadPoolExecutor, as_completed
+          from datetime import datetime, timezone
+
+          TOKEN = os.environ["STARGAZER_TOKEN"]
+          API = "https://api.github.com"
+          REPOSITORY = "lexmount/moli"
+          HEADERS = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {TOKEN}",
+              "X-GitHub-Api-Version": "2022-11-28",
+              "User-Agent": "lexmount-moli-stargazer-export",
+          }
+
+          def api_get(path, accept=None, attempts=6):
+              headers = dict(HEADERS)
+              if accept:
+                  headers["Accept"] = accept
+              url = f"{API}{path}"
+              for attempt in range(attempts):
+                  req = urllib.request.Request(url, headers=headers)
+                  try:
+                      with urllib.request.urlopen(req, timeout=45) as response:
+                          return json.load(response)
+                  except urllib.error.HTTPError as exc:
+                      if exc.code == 404:
+                          return None
+                      if exc.code in (403, 429) or 500 <= exc.code < 600:
+                          retry_after = exc.headers.get("Retry-After")
+                          reset_at = exc.headers.get("X-RateLimit-Reset")
+                          if retry_after:
+                              delay = min(float(retry_after), 120)
+                          elif exc.code == 403 and reset_at:
+                              delay = max(1, min(int(reset_at) - int(time.time()) + 2, 120))
+                          else:
+                              delay = min(2 ** attempt + random.random(), 60)
+                          time.sleep(delay)
+                          continue
+                      raise
+                  except (urllib.error.URLError, TimeoutError):
+                      if attempt == attempts - 1:
+                          raise
+                      time.sleep(min(2 ** attempt + random.random(), 30))
+              raise RuntimeError(f"GitHub API request failed after retries: {path}")
+
+          stargazers = []
+          page = 1
+          while True:
+              batch = api_get(
+                  f"/repos/{REPOSITORY}/stargazers?per_page=100&page={page}",
+                  accept="application/vnd.github.star+json",
+              )
+              if not batch:
+                  break
+              stargazers.extend(batch)
+              print(f"Fetched stargazer page {page}: {len(batch)} users")
+              if len(batch) < 100:
+                  break
+              page += 1
+
+          def fetch_profile(item):
+              user = item.get("user") or {}
+              login = user.get("login")
+              base = {
+                  "login": login,
+                  "starred_at": item.get("starred_at"),
+                  "profile_url": user.get("html_url") or (f"https://github.com/{login}" if login else None),
+                  "account_type": user.get("type"),
+              }
+              if not login:
+                  base["profile_error"] = "missing_login"
+                  return base
+              try:
+                  profile = api_get(f"/users/{urllib.parse.quote(login)}")
+                  if not profile:
+                      base["profile_error"] = "profile_not_found"
+                      return base
+                  base.update({
+                      "name": profile.get("name"),
+                      "company": profile.get("company"),
+                      "location": profile.get("location"),
+                      "bio": profile.get("bio"),
+                      "blog": profile.get("blog"),
+                      "twitter_username": profile.get("twitter_username"),
+                      "public_repos": profile.get("public_repos"),
+                      "followers": profile.get("followers"),
+                      "following": profile.get("following"),
+                      "hireable": profile.get("hireable"),
+                      "account_created_at": profile.get("created_at"),
+                      "account_updated_at": profile.get("updated_at"),
+                      "profile_error": None,
+                  })
+                  return base
+              except Exception as exc:
+                  base["profile_error"] = type(exc).__name__
+                  return base
+
+          profiles = []
+          with ThreadPoolExecutor(max_workers=4) as pool:
+              futures = {pool.submit(fetch_profile, item): item for item in stargazers}
+              for index, future in enumerate(as_completed(futures), 1):
+                  profiles.append(future.result())
+                  if index % 100 == 0:
+                      print(f"Fetched {index}/{len(stargazers)} profiles")
+
+          profiles.sort(key=lambda row: row.get("starred_at") or "", reverse=True)
+          fields = [
+              "login", "name", "starred_at", "profile_url", "account_type",
+              "company", "location", "bio", "blog", "twitter_username",
+              "public_repos", "followers", "following", "hireable",
+              "account_created_at", "account_updated_at", "profile_error",
+          ]
+
+          with open("moli-stargazers.csv", "w", newline="", encoding="utf-8-sig") as handle:
+              writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="ignore")
+              writer.writeheader()
+              writer.writerows(profiles)
+
+          output = {
+              "repository": REPOSITORY,
+              "exported_at": datetime.now(timezone.utc).isoformat(),
+              "stargazer_count": len(stargazers),
+              "profile_count": len(profiles),
+              "profile_error_count": sum(bool(row.get("profile_error")) for row in profiles),
+              "fields": fields,
+              "profiles": profiles,
+          }
+          with open("moli-stargazers.json", "w", encoding="utf-8") as handle:
+              json.dump(output, handle, ensure_ascii=False, indent=2)
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("## Moli stargazer export\n\n")
+              handle.write(f"- Stargazers: {len(stargazers)}\n")
+              handle.write(f"- Profiles: {len(profiles)}\n")
+              handle.write(f"- Profile errors: {output['profile_error_count']}\n")
+          PY
+
+      - name: Upload export
+        uses: actions/upload-artifact@v4
+        with:
+          name: moli-stargazers
+          path: |
+            moli-stargazers.csv
+            moli-stargazers.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -29,7 +29,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $ACTIONS_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/lexmount/moli/actions/runs/33586421382/cancel")
+            "https://api.github.com/repos/lexmount/moli/actions/runs/33587007010/cancel")
           if [ "$code" != "202" ] && [ "$code" != "409" ]; then
             echo "::warning::Could not cancel superseded export run (HTTP $code)."
           fi
@@ -79,9 +79,13 @@ jobs:
                   except urllib.error.HTTPError as exc:
                       if exc.code not in (403, 429) and not 500 <= exc.code < 600:
                           raise
+                      retry_after = exc.headers.get("Retry-After")
+                      remaining = exc.headers.get("X-RateLimit-Remaining")
+                      if exc.code == 403 and remaining != "0" and not retry_after:
+                          body = exc.read().decode("utf-8", errors="replace")
+                          raise RuntimeError(f"GitHub API authorization failed: {body}")
                       if attempt == attempts - 1:
                           raise
-                      retry_after = exc.headers.get("Retry-After")
                       reset_at = exc.headers.get("X-RateLimit-Reset")
                       if retry_after:
                           delay = min(float(retry_after), 120)

--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -13,7 +13,7 @@ jobs:
   export:
     if: github.head_ref == 'codex/export-moli-stargazers'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     env:
       STARGAZER_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -33,145 +33,139 @@ jobs:
           import csv
           import json
           import os
-          import random
           import time
           import urllib.error
-          import urllib.parse
           import urllib.request
-          from concurrent.futures import ThreadPoolExecutor, as_completed
           from datetime import datetime, timezone
 
-          TOKEN = os.environ["STARGAZER_TOKEN"]
-          API = "https://api.github.com"
-          REPOSITORY = "lexmount/moli"
-          HEADERS = {
-              "Accept": "application/vnd.github+json",
-              "Authorization": f"Bearer {TOKEN}",
-              "X-GitHub-Api-Version": "2022-11-28",
-              "User-Agent": "lexmount-moli-stargazer-export",
+          token = os.environ["STARGAZER_TOKEN"]
+          query = """
+          query($owner: String!, $name: String!, $cursor: String) {
+            repository(owner: $owner, name: $name) {
+              stargazers(
+                first: 100
+                after: $cursor
+                orderBy: {field: STARRED_AT, direction: DESC}
+              ) {
+                totalCount
+                pageInfo { hasNextPage endCursor }
+                edges {
+                  starredAt
+                  node {
+                    login
+                    name
+                    url
+                    company
+                    location
+                    bio
+                    websiteUrl
+                    twitterUsername
+                    repositories { totalCount }
+                    followers { totalCount }
+                    following { totalCount }
+                    isHireable
+                    createdAt
+                    updatedAt
+                  }
+                }
+              }
+            }
           }
+          """
 
-          def api_get(path, accept=None, attempts=6):
-              headers = dict(HEADERS)
-              if accept:
-                  headers["Accept"] = accept
-              url = f"{API}{path}"
+          def graphql(variables, attempts=6):
+              payload = json.dumps({"query": query, "variables": variables}).encode()
+              request = urllib.request.Request(
+                  "https://api.github.com/graphql",
+                  data=payload,
+                  method="POST",
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "Content-Type": "application/json",
+                      "User-Agent": "lexmount-moli-stargazer-export",
+                  },
+              )
               for attempt in range(attempts):
-                  req = urllib.request.Request(url, headers=headers)
                   try:
-                      with urllib.request.urlopen(req, timeout=45) as response:
-                          return json.load(response)
-                  except urllib.error.HTTPError as exc:
-                      if exc.code == 404:
-                          return None
-                      if exc.code in (403, 429) or 500 <= exc.code < 600:
-                          retry_after = exc.headers.get("Retry-After")
-                          reset_at = exc.headers.get("X-RateLimit-Reset")
-                          if retry_after:
-                              delay = min(float(retry_after), 120)
-                          elif exc.code == 403 and reset_at:
-                              delay = max(1, min(int(reset_at) - int(time.time()) + 2, 120))
-                          else:
-                              delay = min(2 ** attempt + random.random(), 60)
-                          time.sleep(delay)
-                          continue
-                      raise
+                      with urllib.request.urlopen(request, timeout=60) as response:
+                          result = json.load(response)
+                      if result.get("errors"):
+                          raise RuntimeError(json.dumps(result["errors"], ensure_ascii=False))
+                      return result["data"]
                   except (urllib.error.URLError, TimeoutError):
                       if attempt == attempts - 1:
                           raise
-                      time.sleep(min(2 ** attempt + random.random(), 30))
-              raise RuntimeError(f"GitHub API request failed after retries: {path}")
+                      time.sleep(min(2 ** attempt, 30))
+              raise RuntimeError("GraphQL request failed after retries")
 
-          stargazers = []
-          page = 1
+          rows = []
+          cursor = None
+          expected_total = None
+          page = 0
           while True:
-              batch = api_get(
-                  f"/repos/{REPOSITORY}/stargazers?per_page=100&page={page}",
-                  accept="application/vnd.github.star+json",
-              )
-              if not batch:
-                  break
-              stargazers.extend(batch)
-              print(f"Fetched stargazer page {page}: {len(batch)} users")
-              if len(batch) < 100:
-                  break
               page += 1
-
-          def fetch_profile(item):
-              user = item.get("user") or {}
-              login = user.get("login")
-              base = {
-                  "login": login,
-                  "starred_at": item.get("starred_at"),
-                  "profile_url": user.get("html_url") or (f"https://github.com/{login}" if login else None),
-                  "account_type": user.get("type"),
-              }
-              if not login:
-                  base["profile_error"] = "missing_login"
-                  return base
-              try:
-                  profile = api_get(f"/users/{urllib.parse.quote(login)}")
-                  if not profile:
-                      base["profile_error"] = "profile_not_found"
-                      return base
-                  base.update({
-                      "name": profile.get("name"),
-                      "company": profile.get("company"),
-                      "location": profile.get("location"),
-                      "bio": profile.get("bio"),
-                      "blog": profile.get("blog"),
-                      "twitter_username": profile.get("twitter_username"),
-                      "public_repos": profile.get("public_repos"),
-                      "followers": profile.get("followers"),
-                      "following": profile.get("following"),
-                      "hireable": profile.get("hireable"),
-                      "account_created_at": profile.get("created_at"),
-                      "account_updated_at": profile.get("updated_at"),
+              data = graphql({"owner": "lexmount", "name": "moli", "cursor": cursor})
+              connection = data["repository"]["stargazers"]
+              expected_total = connection["totalCount"]
+              for edge in connection["edges"]:
+                  user = edge["node"]
+                  rows.append({
+                      "login": user.get("login"),
+                      "name": user.get("name"),
+                      "starred_at": edge.get("starredAt"),
+                      "profile_url": user.get("url"),
+                      "account_type": "User",
+                      "company": user.get("company"),
+                      "location": user.get("location"),
+                      "bio": user.get("bio"),
+                      "blog": user.get("websiteUrl"),
+                      "twitter_username": user.get("twitterUsername"),
+                      "public_repos": (user.get("repositories") or {}).get("totalCount"),
+                      "followers": (user.get("followers") or {}).get("totalCount"),
+                      "following": (user.get("following") or {}).get("totalCount"),
+                      "hireable": user.get("isHireable"),
+                      "account_created_at": user.get("createdAt"),
+                      "account_updated_at": user.get("updatedAt"),
                       "profile_error": None,
                   })
-                  return base
-              except Exception as exc:
-                  base["profile_error"] = type(exc).__name__
-                  return base
+              print(f"Fetched page {page}: {len(connection['edges'])} users; total {len(rows)}/{expected_total}")
+              page_info = connection["pageInfo"]
+              if not page_info["hasNextPage"]:
+                  break
+              cursor = page_info["endCursor"]
 
-          profiles = []
-          with ThreadPoolExecutor(max_workers=4) as pool:
-              futures = {pool.submit(fetch_profile, item): item for item in stargazers}
-              for index, future in enumerate(as_completed(futures), 1):
-                  profiles.append(future.result())
-                  if index % 100 == 0:
-                      print(f"Fetched {index}/{len(stargazers)} profiles")
-
-          profiles.sort(key=lambda row: row.get("starred_at") or "", reverse=True)
           fields = [
               "login", "name", "starred_at", "profile_url", "account_type",
               "company", "location", "bio", "blog", "twitter_username",
               "public_repos", "followers", "following", "hireable",
               "account_created_at", "account_updated_at", "profile_error",
           ]
-
           with open("moli-stargazers.csv", "w", newline="", encoding="utf-8-sig") as handle:
-              writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="ignore")
+              writer = csv.DictWriter(handle, fieldnames=fields)
               writer.writeheader()
-              writer.writerows(profiles)
+              writer.writerows(rows)
 
           output = {
-              "repository": REPOSITORY,
+              "repository": "lexmount/moli",
               "exported_at": datetime.now(timezone.utc).isoformat(),
-              "stargazer_count": len(stargazers),
-              "profile_count": len(profiles),
-              "profile_error_count": sum(bool(row.get("profile_error")) for row in profiles),
+              "stargazer_count": expected_total,
+              "profile_count": len(rows),
+              "profile_error_count": 0,
               "fields": fields,
-              "profiles": profiles,
+              "profiles": rows,
           }
           with open("moli-stargazers.json", "w", encoding="utf-8") as handle:
               json.dump(output, handle, ensure_ascii=False, indent=2)
 
+          if len(rows) != expected_total:
+              raise RuntimeError(f"Count mismatch: fetched {len(rows)}, expected {expected_total}")
+
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
               handle.write("## Moli stargazer export\n\n")
-              handle.write(f"- Stargazers: {len(stargazers)}\n")
-              handle.write(f"- Profiles: {len(profiles)}\n")
-              handle.write(f"- Profile errors: {output['profile_error_count']}\n")
+              handle.write(f"- Stargazers: {expected_total}\n")
+              handle.write(f"- Profiles: {len(rows)}\n")
+              handle.write("- Profile errors: 0\n")
           PY
 
       - name: Upload export

--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   export:
@@ -18,6 +19,21 @@ jobs:
       STARGAZER_TOKEN: ${{ secrets.GH_TOKEN }}
 
     steps:
+      - name: Cancel superseded export run
+        env:
+          ACTIONS_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          code=$(curl -sS -o /tmp/cancel-response.txt -w "%{http_code}" \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $ACTIONS_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/lexmount/moli/actions/runs/33586421382/cancel")
+          if [ "$code" != "202" ] && [ "$code" != "409" ]; then
+            echo "::warning::Could not cancel superseded export run (HTTP $code)."
+          fi
+
       - name: Verify token is configured
         shell: bash
         run: |
@@ -60,6 +76,21 @@ jobs:
                   try:
                       with urllib.request.urlopen(request, timeout=60) as response:
                           return json.load(response)
+                  except urllib.error.HTTPError as exc:
+                      if exc.code not in (403, 429) and not 500 <= exc.code < 600:
+                          raise
+                      if attempt == attempts - 1:
+                          raise
+                      retry_after = exc.headers.get("Retry-After")
+                      reset_at = exc.headers.get("X-RateLimit-Reset")
+                      if retry_after:
+                          delay = min(float(retry_after), 120)
+                      elif reset_at:
+                          delay = max(2, min(int(reset_at) - int(time.time()) + 2, 120))
+                      else:
+                          delay = min(2 ** attempt, 60)
+                      print(f"GitHub API returned {exc.code}; retrying in {delay:.0f}s")
+                      time.sleep(delay)
                   except (urllib.error.URLError, TimeoutError):
                       if attempt == attempts - 1:
                           raise

--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      STARGAZER_TOKEN: ${{ github.token }}
+      STARGAZER_TOKEN: ${{ secrets.GH_TOKEN }}
 
     steps:
       - name: Cancel superseded export run
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           if [ -z "$STARGAZER_TOKEN" ]; then
-            echo "::error::GitHub Actions token is unavailable."
+            echo "::error::Repository secret GH_TOKEN is not configured or unavailable."
             exit 1
           fi
 

--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -1,4 +1,4 @@
-name: Export Moli stargazers
+name: Export Moli community interactions
 
 on:
   pull_request:
@@ -8,58 +8,47 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   export:
     if: github.head_ref == 'codex/export-moli-stargazers'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
-      STARGAZER_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_EXPORT_TOKEN: ${{ secrets.GH_TOKEN }}
 
     steps:
-      - name: Cancel superseded export run
-        env:
-          ACTIONS_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          code=$(curl -sS -o /tmp/cancel-response.txt -w "%{http_code}" \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $ACTIONS_TOKEN" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/lexmount/moli/actions/runs/33587007010/cancel")
-          if [ "$code" != "202" ] && [ "$code" != "409" ]; then
-            echo "::warning::Could not cancel superseded export run (HTTP $code)."
-          fi
-
       - name: Verify token is configured
         shell: bash
         run: |
-          if [ -z "$STARGAZER_TOKEN" ]; then
+          if [ -z "$GH_EXPORT_TOKEN" ]; then
             echo "::error::Repository secret GH_TOKEN is not configured or unavailable."
             exit 1
           fi
 
-      - name: Export public stargazer profiles
+      - name: Export public community interactions
         shell: bash
         run: |
           python3 - <<'PY'
           import csv
           import json
+          import math
           import os
           import time
           import urllib.error
+          import urllib.parse
           import urllib.request
+          from collections import defaultdict
           from datetime import datetime, timezone
 
-          token = os.environ["STARGAZER_TOKEN"]
+          token = os.environ["GH_EXPORT_TOKEN"]
+          repo = "lexmount/moli"
+          api = f"https://api.github.com/repos/{repo}"
           headers = {
               "Accept": "application/vnd.github+json",
               "Authorization": f"Bearer {token}",
               "X-GitHub-Api-Version": "2022-11-28",
-              "User-Agent": "lexmount-moli-stargazer-export",
+              "User-Agent": "lexmount-moli-community-export",
           }
 
           def request_json(url, data=None, attempts=6, extra_headers=None):
@@ -78,14 +67,11 @@ jobs:
                           return json.load(response)
                   except urllib.error.HTTPError as exc:
                       if exc.code not in (403, 429) and not 500 <= exc.code < 600:
-                          raise
-                      retry_after = exc.headers.get("Retry-After")
-                      remaining = exc.headers.get("X-RateLimit-Remaining")
-                      if exc.code == 403 and remaining != "0" and not retry_after:
                           body = exc.read().decode("utf-8", errors="replace")
-                          raise RuntimeError(f"GitHub API authorization failed: {body}")
+                          raise RuntimeError(f"GitHub API error {exc.code}: {body}")
                       if attempt == attempts - 1:
                           raise
+                      retry_after = exc.headers.get("Retry-After")
                       reset_at = exc.headers.get("X-RateLimit-Reset")
                       if retry_after:
                           delay = min(float(retry_after), 120)
@@ -101,28 +87,66 @@ jobs:
                       time.sleep(min(2 ** attempt, 30))
               raise RuntimeError(f"Request failed after retries: {url}")
 
-          repository = request_json("https://api.github.com/repos/lexmount/moli")
-          print("Repository token diagnostics:", json.dumps({
-              "repository_full_name": repository.get("full_name"),
-              "repository_visibility": repository.get("visibility"),
-              "repository_permissions": repository.get("permissions"),
-          }, ensure_ascii=False))
+          def paginate(url):
+              rows = []
+              page = 1
+              separator = "&" if "?" in url else "?"
+              while True:
+                  batch = request_json(f"{url}{separator}per_page=100&page={page}")
+                  if not batch:
+                      break
+                  rows.extend(batch)
+                  print(f"Fetched {url}: page {page}, {len(batch)} records")
+                  if len(batch) < 100:
+                      break
+                  page += 1
+              return rows
 
-          stargazers = []
-          page = 1
-          while True:
-              url = f"https://api.github.com/repos/lexmount/moli/stargazers?per_page=100&page={page}"
-              batch = request_json(
-                  url,
-                  extra_headers={"Accept": "application/vnd.github.star+json"},
-              )
-              if not batch:
-                  break
-              stargazers.extend(batch)
-              print(f"Fetched stargazer page {page}: {len(batch)} users")
-              if len(batch) < 100:
-                  break
-              page += 1
+          repository = request_json(api)
+          print("Repository:", repository.get("full_name"), repository.get("visibility"))
+
+          forks = paginate(f"{api}/forks?sort=newest")
+          contributors = paginate(f"{api}/contributors?anon=1")
+          all_issues = paginate(f"{api}/issues?state=all&sort=created&direction=desc")
+          issue_comments = paginate(f"{api}/issues/comments?sort=created&direction=desc")
+          issues = [item for item in all_issues if "pull_request" not in item]
+          pulls = [item for item in all_issues if "pull_request" in item]
+
+          pr_reviews = []
+          pr_review_comments = []
+          for pull in pulls:
+              number = pull["number"]
+              for review in paginate(f"{api}/pulls/{number}/reviews?"):
+                  review["_pull_number"] = number
+                  pr_reviews.append(review)
+              for comment in paginate(f"{api}/pulls/{number}/comments?"):
+                  comment["_pull_number"] = number
+                  pr_review_comments.append(comment)
+
+          def login_of(value):
+              if not value:
+                  return None
+              if isinstance(value, dict):
+                  return value.get("login")
+              return None
+
+          logins = set()
+          for fork in forks:
+              login = login_of(fork.get("owner"))
+              if login:
+                  logins.add(login)
+          for contributor in contributors:
+              login = contributor.get("login")
+              if login:
+                  logins.add(login)
+          for item in issues + pulls:
+              login = login_of(item.get("user"))
+              if login:
+                  logins.add(login)
+          for item in issue_comments + pr_reviews + pr_review_comments:
+              login = login_of(item.get("user"))
+              if login:
+                  logins.add(login)
 
           profile_fields = """
             login name url company location bio websiteUrl twitterUsername
@@ -131,92 +155,293 @@ jobs:
             following { totalCount }
             isHireable createdAt updatedAt
           """
-
-          profiles_by_login = {}
-          logins = [item["user"]["login"] for item in stargazers if item.get("user")]
-          for start in range(0, len(logins), 50):
-              chunk = logins[start:start + 50]
-              aliases = []
-              for index, login in enumerate(chunk):
-                  aliases.append(
-                      f'u{index}: user(login: {json.dumps(login)}) {{ {profile_fields} }}'
-                  )
-              query = "query { " + " ".join(aliases) + " }"
-              payload = json.dumps({"query": query}).encode()
+          profiles = {}
+          ordered_logins = sorted(logins, key=str.lower)
+          for start in range(0, len(ordered_logins), 50):
+              chunk = ordered_logins[start:start + 50]
+              aliases = [
+                  f'u{index}: user(login: {json.dumps(login)}) {{ {profile_fields} }}'
+                  for index, login in enumerate(chunk)
+              ]
+              payload = json.dumps({"query": "query { " + " ".join(aliases) + " }"}).encode()
               result = request_json(
                   "https://api.github.com/graphql",
                   data=payload,
                   extra_headers={"Content-Type": "application/json"},
               )
-              if result.get("errors"):
-                  print("GraphQL partial errors:", json.dumps(result["errors"], ensure_ascii=False))
               data = result.get("data") or {}
               for index, login in enumerate(chunk):
-                  profiles_by_login[login] = data.get(f"u{index}")
-              print(f"Enriched {min(start + len(chunk), len(logins))}/{len(logins)} profiles")
+                  profiles[login] = data.get(f"u{index}") or {}
+              print(f"Enriched {min(start + len(chunk), len(ordered_logins))}/{len(ordered_logins)} profiles")
 
-          rows = []
-          for item in stargazers:
-              user_stub = item.get("user") or {}
-              login = user_stub.get("login")
-              user = profiles_by_login.get(login) or {}
-              rows.append({
+          people = defaultdict(lambda: {
+              "fork_count": 0,
+              "fork_latest_at": None,
+              "contributions": 0,
+              "issue_opened": 0,
+              "issue_commented": 0,
+              "pr_opened": 0,
+              "pr_merged": 0,
+              "pr_reviewed": 0,
+              "pr_review_commented": 0,
+              "last_interaction_at": None,
+              "interaction_types": set(),
+              "source_urls": set(),
+          })
+
+          def touch(login, kind, when=None, url=None):
+              if not login:
+                  return
+              row = people[login]
+              row["interaction_types"].add(kind)
+              if url:
+                  row["source_urls"].add(url)
+              if when and (not row["last_interaction_at"] or when > row["last_interaction_at"]):
+                  row["last_interaction_at"] = when
+
+          for fork in forks:
+              login = login_of(fork.get("owner"))
+              if not login:
+                  continue
+              row = people[login]
+              row["fork_count"] += 1
+              when = fork.get("created_at") or fork.get("updated_at")
+              if when and (not row["fork_latest_at"] or when > row["fork_latest_at"]):
+                  row["fork_latest_at"] = when
+              touch(login, "Fork", when, fork.get("html_url"))
+
+          for contributor in contributors:
+              login = contributor.get("login")
+              if not login:
+                  continue
+              people[login]["contributions"] += int(contributor.get("contributions") or 0)
+              touch(login, "Contributor", None, f"https://github.com/{repo}/commits?author={urllib.parse.quote(login)}")
+
+          for issue in issues:
+              login = login_of(issue.get("user"))
+              if not login:
+                  continue
+              people[login]["issue_opened"] += 1
+              touch(login, "Issue author", issue.get("created_at"), issue.get("html_url"))
+
+          for comment in issue_comments:
+              login = login_of(comment.get("user"))
+              issue_url = comment.get("issue_url") or ""
+              number = issue_url.rstrip("/").split("/")[-1] if issue_url else ""
+              url = f"https://github.com/{repo}/issues/{number}#issuecomment-{comment.get('id')}" if number else None
+              if not login:
+                  continue
+              people[login]["issue_commented"] += 1
+              touch(login, "Issue/PR comment", comment.get("created_at"), url)
+
+          for pull in pulls:
+              login = login_of(pull.get("user"))
+              if not login:
+                  continue
+              people[login]["pr_opened"] += 1
+              if pull.get("pull_request", {}).get("merged_at"):
+                  people[login]["pr_merged"] += 1
+              touch(login, "PR author", pull.get("created_at"), pull.get("html_url"))
+
+          for review in pr_reviews:
+              login = login_of(review.get("user"))
+              if not login:
+                  continue
+              people[login]["pr_reviewed"] += 1
+              number = review.get("_pull_number")
+              touch(login, "PR reviewer", review.get("submitted_at"), f"https://github.com/{repo}/pull/{number}")
+
+          for comment in pr_review_comments:
+              login = login_of(comment.get("user"))
+              if not login:
+                  continue
+              people[login]["pr_review_commented"] += 1
+              number = comment.get("_pull_number")
+              url = comment.get("html_url") or f"https://github.com/{repo}/pull/{number}"
+              touch(login, "PR review comment", comment.get("created_at"), url)
+
+          def interaction_score(row):
+              score = 0
+              if row["fork_count"]:
+                  score += 1
+              contributions = row["contributions"]
+              if contributions >= 10:
+                  score += 5
+              elif contributions >= 3:
+                  score += 4
+              elif contributions >= 1:
+                  score += 3
+              score += min(6, row["issue_opened"] * 3)
+              score += min(4, row["issue_commented"] * 2)
+              score += min(7, row["pr_opened"] * 4 + row["pr_merged"] * 2)
+              score += min(4, row["pr_reviewed"] * 3)
+              score += min(3, row["pr_review_commented"] * 2)
+              return score
+
+          output_rows = []
+          for login, interaction in people.items():
+              profile = profiles.get(login) or {}
+              score = interaction_score(interaction)
+              if score >= 7:
+                  tier = "A"
+              elif score >= 3:
+                  tier = "B"
+              else:
+                  tier = "C"
+              if interaction["issue_opened"] or interaction["issue_commented"]:
+                  angle = "Issue follow-up / technical interview"
+              elif interaction["pr_opened"] or interaction["pr_reviewed"] or interaction["contributions"]:
+                  angle = "Contributor interview / ecosystem collaboration"
+              elif interaction["fork_count"]:
+                  angle = "Fork use-case validation"
+              else:
+                  angle = "Manual review"
+              types = sorted(interaction["interaction_types"])
+              urls = sorted(interaction["source_urls"])
+              total = (
+                  interaction["fork_count"] + interaction["issue_opened"] +
+                  interaction["issue_commented"] + interaction["pr_opened"] +
+                  interaction["pr_reviewed"] + interaction["pr_review_commented"]
+              )
+              output_rows.append({
                   "login": login,
-                  "name": user.get("name"),
-                  "starred_at": item.get("starred_at"),
-                  "profile_url": user.get("url") or user_stub.get("html_url"),
-                  "account_type": user_stub.get("type"),
-                  "company": user.get("company"),
-                  "location": user.get("location"),
-                  "bio": user.get("bio"),
-                  "blog": user.get("websiteUrl"),
-                  "twitter_username": user.get("twitterUsername"),
-                  "public_repos": (user.get("repositories") or {}).get("totalCount"),
-                  "followers": (user.get("followers") or {}).get("totalCount"),
-                  "following": (user.get("following") or {}).get("totalCount"),
-                  "hireable": user.get("isHireable"),
-                  "account_created_at": user.get("createdAt"),
-                  "account_updated_at": user.get("updatedAt"),
-                  "profile_error": None if user else "profile_unavailable",
+                  "name": profile.get("name"),
+                  "profile_url": profile.get("url") or f"https://github.com/{login}",
+                  "company": profile.get("company"),
+                  "location": profile.get("location"),
+                  "bio": profile.get("bio"),
+                  "blog": profile.get("websiteUrl"),
+                  "twitter_username": profile.get("twitterUsername"),
+                  "followers": (profile.get("followers") or {}).get("totalCount"),
+                  "public_repos": (profile.get("repositories") or {}).get("totalCount"),
+                  "fork_count": interaction["fork_count"],
+                  "fork_latest_at": interaction["fork_latest_at"],
+                  "contributions": interaction["contributions"],
+                  "issue_opened": interaction["issue_opened"],
+                  "issue_commented": interaction["issue_commented"],
+                  "pr_opened": interaction["pr_opened"],
+                  "pr_merged": interaction["pr_merged"],
+                  "pr_reviewed": interaction["pr_reviewed"],
+                  "pr_review_commented": interaction["pr_review_commented"],
+                  "total_interactions": total,
+                  "last_interaction_at": interaction["last_interaction_at"],
+                  "interaction_types": "; ".join(types),
+                  "interaction_score": score,
+                  "interaction_tier": tier,
+                  "recommended_angle": angle,
+                  "source_urls": "; ".join(urls),
+                  "is_bot": login.lower().endswith("[bot]") or login.lower().endswith("-bot"),
               })
 
+          output_rows.sort(
+              key=lambda row: (
+                  row["is_bot"],
+                  -row["interaction_score"],
+                  -(row["followers"] or 0),
+                  row["login"].lower(),
+              )
+          )
+
           fields = [
-              "login", "name", "starred_at", "profile_url", "account_type",
-              "company", "location", "bio", "blog", "twitter_username",
-              "public_repos", "followers", "following", "hireable",
-              "account_created_at", "account_updated_at", "profile_error",
+              "login", "name", "profile_url", "company", "location", "bio", "blog",
+              "twitter_username", "followers", "public_repos", "fork_count",
+              "fork_latest_at", "contributions", "issue_opened", "issue_commented",
+              "pr_opened", "pr_merged", "pr_reviewed", "pr_review_commented",
+              "total_interactions", "last_interaction_at", "interaction_types",
+              "interaction_score", "interaction_tier", "recommended_angle",
+              "source_urls", "is_bot",
           ]
-          with open("moli-stargazers.csv", "w", newline="", encoding="utf-8-sig") as handle:
+          with open("moli-community-interactions.csv", "w", newline="", encoding="utf-8-sig") as handle:
               writer = csv.DictWriter(handle, fieldnames=fields)
               writer.writeheader()
-              writer.writerows(rows)
+              writer.writerows(output_rows)
 
-          error_count = sum(bool(row["profile_error"]) for row in rows)
-          output = {
-              "repository": "lexmount/moli",
-              "exported_at": datetime.now(timezone.utc).isoformat(),
-              "stargazer_count": len(stargazers),
-              "profile_count": len(rows),
-              "profile_error_count": error_count,
-              "fields": fields,
-              "profiles": rows,
+          def slim_user(user):
+              if not user:
+                  return None
+              return {"login": user.get("login"), "type": user.get("type"), "html_url": user.get("html_url")}
+
+          raw = {
+              "forks": [
+                  {
+                      "owner": slim_user(item.get("owner")),
+                      "full_name": item.get("full_name"),
+                      "html_url": item.get("html_url"),
+                      "created_at": item.get("created_at"),
+                      "updated_at": item.get("updated_at"),
+                      "pushed_at": item.get("pushed_at"),
+                  } for item in forks
+              ],
+              "contributors": [
+                  {
+                      "login": item.get("login"),
+                      "type": item.get("type"),
+                      "contributions": item.get("contributions"),
+                      "html_url": item.get("html_url"),
+                  } for item in contributors
+              ],
+              "issues": [
+                  {
+                      "number": item.get("number"),
+                      "title": item.get("title"),
+                      "state": item.get("state"),
+                      "user": slim_user(item.get("user")),
+                      "comments": item.get("comments"),
+                      "created_at": item.get("created_at"),
+                      "updated_at": item.get("updated_at"),
+                      "html_url": item.get("html_url"),
+                  } for item in issues
+              ],
+              "pull_requests": [
+                  {
+                      "number": item.get("number"),
+                      "title": item.get("title"),
+                      "state": item.get("state"),
+                      "user": slim_user(item.get("user")),
+                      "comments": item.get("comments"),
+                      "created_at": item.get("created_at"),
+                      "updated_at": item.get("updated_at"),
+                      "html_url": item.get("html_url"),
+                  } for item in pulls
+              ],
           }
-          with open("moli-stargazers.json", "w", encoding="utf-8") as handle:
-              json.dump(output, handle, ensure_ascii=False, indent=2)
+          summary = {
+              "repository": repo,
+              "exported_at": datetime.now(timezone.utc).isoformat(),
+              "forks": len(forks),
+              "contributors": len(contributors),
+              "issues": len(issues),
+              "issue_comments": len(issue_comments),
+              "pull_requests": len(pulls),
+              "pull_request_reviews": len(pr_reviews),
+              "pull_request_review_comments": len(pr_review_comments),
+              "unique_people": len(output_rows),
+              "tier_counts": {
+                  tier: sum(row["interaction_tier"] == tier for row in output_rows)
+                  for tier in ("A", "B", "C")
+              },
+              "method_note": "Public GitHub activity only. Bots are marked. Internal/team accounts should be excluded during manual outreach review.",
+          }
+          with open("moli-community-interactions.json", "w", encoding="utf-8") as handle:
+              json.dump({"summary": summary, "people": output_rows, "raw": raw}, handle, ensure_ascii=False, indent=2)
+          with open("moli-community-summary.json", "w", encoding="utf-8") as handle:
+              json.dump(summary, handle, ensure_ascii=False, indent=2)
 
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
-              handle.write("## Moli stargazer export\n\n")
-              handle.write(f"- Stargazers: {len(stargazers)}\n")
-              handle.write(f"- Profiles: {len(rows)}\n")
-              handle.write(f"- Profile errors: {error_count}\n")
+              handle.write("## Moli community interaction export\n\n")
+              for key, value in summary.items():
+                  if key not in ("tier_counts", "method_note"):
+                      handle.write(f"- {key}: {value}\n")
+              handle.write(f"- tiers: {summary['tier_counts']}\n")
           PY
 
       - name: Upload export
         uses: actions/upload-artifact@v4
         with:
-          name: moli-stargazers
+          name: moli-community-interactions
           path: |
-            moli-stargazers.csv
-            moli-stargazers.json
+            moli-community-interactions.csv
+            moli-community-interactions.json
+            moli-community-summary.json
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -101,11 +101,8 @@ jobs:
                       time.sleep(min(2 ** attempt, 30))
               raise RuntimeError(f"Request failed after retries: {url}")
 
-          viewer = request_json("https://api.github.com/user")
           repository = request_json("https://api.github.com/repos/lexmount/moli")
-          print("Token diagnostics:", json.dumps({
-              "login": viewer.get("login"),
-              "token_type": viewer.get("type"),
+          print("Repository token diagnostics:", json.dumps({
               "repository_full_name": repository.get("full_name"),
               "repository_visibility": repository.get("visibility"),
               "repository_permissions": repository.get("permissions"),

--- a/.github/workflows/export-moli-stargazers.yml
+++ b/.github/workflows/export-moli-stargazers.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      STARGAZER_TOKEN: ${{ secrets.GH_TOKEN }}
+      STARGAZER_TOKEN: ${{ github.token }}
 
     steps:
       - name: Cancel superseded export run
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           if [ -z "$STARGAZER_TOKEN" ]; then
-            echo "::error::Repository secret GH_TOKEN is not configured or unavailable."
+            echo "::error::GitHub Actions token is unavailable."
             exit 1
           fi
 


### PR DESCRIPTION
Temporary read-only workflow to export the repository's stargazer list and enrich it with public GitHub profile fields. The workflow uses the repository `GH_TOKEN` secret, does not print the token, and uploads CSV/JSON artifacts for seven days. This PR is not intended to merge.