### PR TITLE
fix(style): activate @container size queries from definite computed sizes

### DIFF
--- a/moli-renderer-v8/src/script_vm/tests/dom_xhr/computed_style.rs
+++ b/moli-renderer-v8/src/script_vm/tests/dom_xhr/computed_style.rs
@@ -2257,6 +2257,42 @@ fn container_style_queries_resolve_direct_typed_attr_values() {
 }
 
 #[test]
+fn container_size_queries_activate_from_stylesheet_container_dimensions() {
+    let mut vm = new_storage_test_vm("https://container-stylesheet-size-query.test/");
+
+    let result = vm
+        .eval(
+            r#"
+(() => {
+  const root = document.documentElement || document.appendChild(document.createElement('html'));
+  const head = document.head || root.appendChild(document.createElement('head'));
+  const body = document.body || root.appendChild(document.createElement('body'));
+  const style = document.createElement('style');
+  style.textContent = `
+    #cqbox { container-type: inline-size; width: 300px; }
+    .inner { color: blue; }
+    @container (min-width: 200px) { .inner { color: red; } }
+    .widen { color: purple; }
+    @container (min-width: 400px) { .widen { color: green; } }
+  `;
+  head.appendChild(style);
+  const box = document.createElement('div');
+  box.id = 'cqbox';
+  box.innerHTML = '<div class="inner" id="cqinner">t</div><div class="widen" id="wideinner">w</div>';
+  body.appendChild(box);
+  return [
+    getComputedStyle(document.getElementById('cqinner')).color,
+    getComputedStyle(document.getElementById('wideinner')).color
+  ].join('|');
+})()
+"#,
+        )
+        .expect("stylesheet container size query should activate");
+
+    assert_eq!(result, "rgb(255, 0, 0)|rgb(128, 0, 128)");
+}
+
+#[test]
 fn implicit_scope_root_for_owner_stylesheet_matches_parent_element() {
     let mut vm = new_storage_test_vm("https://implicit-scope-root.test/");
 

--- a/moli-selector/src/stylo/style_traversal.rs
+++ b/moli-selector/src/stylo/style_traversal.rs
@@ -23,12 +23,17 @@ use style::{
     data::{ElementDataMut, ElementDataRef, ElementDataWrapper},
     dom::{LayoutIterator, NodeInfo, OpaqueNode, TDocument, TElement, TNode, TShadowRoot},
     invalidation::{element::restyle_hints::RestyleHint, stylesheets::StylesheetInvalidationSet},
-    properties::{PropertyDeclarationBlock, longhands::display::computed_value::T as Display},
+    properties::{
+        ComputedValues, PropertyDeclarationBlock,
+        longhands::{
+            box_sizing::computed_value::T as BoxSizing, display::computed_value::T as Display,
+        },
+    },
     selector_parser::{AttrValue as SelectorAttrValue, Lang, PseudoElement, SelectorImpl},
     servo_arc::{Arc, ArcBorrow},
     shared_lock::{Locked, SharedRwLock},
     stylist::CascadeData,
-    values::AtomIdent,
+    values::{AtomIdent, computed::NonNegativeLengthPercentage, generics::length::GenericSize},
 };
 
 use crate::{
@@ -2130,7 +2135,10 @@ impl<'a> TElement for StyleElement<'a> {
     }
 
     fn query_container_size(&self, _: &Display) -> Size2D<Option<Au>> {
-        inline_container_size(self.host(), self.handle())
+        match computed_container_size(self) {
+            Some(size) => size,
+            None => inline_container_size(self.host(), self.handle()),
+        }
     }
 
     fn has_selector_flags(&self, flags: ElementSelectorFlags) -> bool {
@@ -2172,6 +2180,65 @@ fn inline_container_size(host: &DomHost, handle: NodeId) -> Size2D<Option<Au>> {
         }
     }
     Size2D::new(width, height)
+}
+
+/// Resolves a container element's own content-box size from its already
+/// cascaded computed style. Returns `None` when the element has no computed
+/// style published yet, in which case callers should fall back to another
+/// size source. Layout-dependent sizes (auto, percentages, intrinsic keywords,
+/// min/max-constrained widths) come back as `None` for the affected axis.
+fn computed_container_size(element: &StyleElement<'_>) -> Option<Size2D<Option<Au>>> {
+    let data = element.borrow_data()?;
+    let style = data.styles.get_primary()?.clone();
+    let width = computed_axis_content_size(&style, ContainerAxis::Horizontal);
+    let height = computed_axis_content_size(&style, ContainerAxis::Vertical);
+    Some(Size2D::new(width, height))
+}
+
+#[derive(Clone, Copy)]
+enum ContainerAxis {
+    Horizontal,
+    Vertical,
+}
+
+/// Returns the content-box extent along `axis` when it is a definite absolute
+/// length in the element's computed style.
+fn computed_axis_content_size(style: &ComputedValues, axis: ContainerAxis) -> Option<Au> {
+    let size = match axis {
+        ContainerAxis::Horizontal => style.clone_width(),
+        ContainerAxis::Vertical => style.clone_height(),
+    };
+    // Only a definite `<length>` (no auto/percentage/intrinsic keyword and no
+    // calc that keeps a percentage) can be reported without running layout.
+    let GenericSize::LengthPercentage(length_percentage) = size else {
+        return None;
+    };
+    let mut au = Au::from(length_percentage.0.to_length()?);
+    if style.clone_box_sizing() == BoxSizing::BorderBox {
+        let (leading_padding, trailing_padding, leading_border, trailing_border) = match axis {
+            ContainerAxis::Horizontal => (
+                style.clone_padding_left(),
+                style.clone_padding_right(),
+                style.clone_border_left_width(),
+                style.clone_border_right_width(),
+            ),
+            ContainerAxis::Vertical => (
+                style.clone_padding_top(),
+                style.clone_padding_bottom(),
+                style.clone_border_top_width(),
+                style.clone_border_bottom_width(),
+            ),
+        };
+        let leading_padding = definite_length_au(leading_padding)?;
+        let trailing_padding = definite_length_au(trailing_padding)?;
+        au = (au - leading_padding - trailing_padding - leading_border.0 - trailing_border.0)
+            .max(Au(0));
+    }
+    Some(au)
+}
+
+fn definite_length_au(length_percentage: NonNegativeLengthPercentage) -> Option<Au> {
+    length_percentage.0.to_length().map(Au::from)
 }
 
 impl SelectorsElement for StyleElement<'_> {


### PR DESCRIPTION
query_container_size only read literal px width/height from the inline
style attribute, so containers sized by a stylesheet reported no size and
@container conditions always evaluated false. Source the container's own
computed style instead: return definite width/height as the content-box
size (subtracting padding/border under border-box), falling back to the
inline-attribute heuristic when no computed style is published yet.