### PR TITLE
fix(dialog): light-dismiss modal dialogs on Escape

### DIFF
--- a/moli-renderer-v8/src/host/events.rs
+++ b/moli-renderer-v8/src/host/events.rs
@@ -1653,6 +1653,9 @@ pub(crate) fn dispatch_public_event_with_original_target<'s, 'i>(
         crate::native_bridge::element::perform_access_key_default_action_for_dispatched_event(
             scope, host_ptr, event,
         );
+        crate::native_bridge::element::perform_dialog_escape_default_action_for_dispatched_event(
+            scope, host_ptr, event,
+        );
     }
     set_event_phase(scope, event, 0);
     set_event_internal_flag(scope, event, EVENT_DISPATCHING_SLOT, false);

--- a/moli-renderer-v8/src/native_bridge/element.rs
+++ b/moli-renderer-v8/src/native_bridge/element.rs
@@ -179,6 +179,7 @@ use details_dialog::{
     dialog_show_modal_callback, perform_summary_click_default_action,
 };
 pub(crate) use details_dialog::{
+    perform_dialog_escape_default_action_for_dispatched_event,
     queue_details_toggle_event_for_attribute_change, queue_parser_details_toggle_event,
     queue_parser_details_toggle_events_in_subtree,
 };

--- a/moli-renderer-v8/src/native_bridge/element/details_dialog.rs
+++ b/moli-renderer-v8/src/native_bridge/element/details_dialog.rs
@@ -13,8 +13,9 @@ use super::super::{
 };
 use super::toggle_event::queue_element_toggle_event;
 use super::{
-    element_has_attribute, html_element_getter_receiver, html_element_setter_receiver,
-    property_dom_string_value, set_reflected_boolean_attribute,
+    construct_simple_event, dispatch_public_event, element_has_attribute,
+    html_element_getter_receiver, html_element_setter_receiver, property_dom_string_value,
+    set_reflected_boolean_attribute,
 };
 
 pub(crate) fn queue_details_toggle_event_for_attribute_change(
@@ -455,4 +456,61 @@ fn queue_dialog_close_event(
         RendererPageUserInteractionEventKind::DialogClose,
         handle,
     );
+}
+
+/// Default action for a trusted `keydown` on Escape: run the spec's
+/// light-dismiss for the topmost open modal dialog. A cancelable, non-bubbling
+/// `cancel` event is fired at the dialog, and the dialog closes unless the
+/// event is canceled (or the keydown itself was prevented, which the caller
+/// already checks).
+pub(crate) fn perform_dialog_escape_default_action_for_dispatched_event(
+    scope: &mut v8::PinScope<'_, '_>,
+    runtime_ptr: *mut JsContextHost,
+    event: v8::Local<'_, v8::Object>,
+) {
+    if event_string_property(scope, event, "key").as_deref() != Some("Escape") {
+        return;
+    }
+    let Some(handle) = topmost_open_modal_dialog(unsafe { &*runtime_ptr }) else {
+        return;
+    };
+    let Some(cancel_event) = construct_simple_event(scope, "cancel", false, true, false) else {
+        return;
+    };
+    let outcome = dispatch_public_event(scope, runtime_ptr, handle, cancel_event);
+    if outcome.allows_default() {
+        close_dialog_element(scope, runtime_ptr, handle, None);
+    }
+}
+
+/// Returns the last connected `<dialog>` that is open as a modal dialog.
+fn topmost_open_modal_dialog(runtime: &JsContextHost) -> Option<DomHandle> {
+    runtime
+        .dom_host()
+        .dom()
+        .nodes()
+        .iter()
+        .rev()
+        .find_map(|node| {
+            if !node.is_connected() {
+                return None;
+            }
+            let element = node.as_element()?;
+            (element.is_html_element("dialog")
+                && element.dialog_modal()
+                && element.attribute("open").is_some())
+            .then_some(node.id())
+        })
+}
+
+fn event_string_property(
+    scope: &mut v8::PinScope<'_, '_>,
+    event: v8::Local<'_, v8::Object>,
+    name: &str,
+) -> Option<String> {
+    let key = v8_string(scope, name)?;
+    event
+        .get(scope, key.into())
+        .and_then(|value| v8::Local::<v8::String>::try_from(value).ok())
+        .map(|value| value.to_rust_string_lossy(scope))
 }

--- a/moli-renderer-v8/src/script_vm/tests/dom_xhr/forms/dialog.rs
+++ b/moli-renderer-v8/src/script_vm/tests/dom_xhr/forms/dialog.rs
@@ -221,3 +221,146 @@ fn dialog_form_submission_distinguishes_absent_and_empty_submitter_values() {
         r#"{"absentValue":{"open":false,"returnValue":"previous","valueAttribute":null},"emptyValue":{"open":false,"returnValue":"","valueAttribute":""}}"#
     );
 }
+
+#[test]
+fn dialog_escape_keydown_light_dismisses_modal_dialog() {
+    let mut vm = new_storage_test_vm("https://dialog-escape-modal.test/");
+
+    vm.eval(
+        r#"
+(() => {
+  const d = document.createElement('dialog');
+  d.id = 'modal';
+  d.innerHTML = '<p>content</p>';
+  (document.body || document.documentElement || document).appendChild(d);
+  window.__events = [];
+  d.addEventListener('cancel', () => { window.__events.push('cancel'); });
+  d.addEventListener('close', () => { window.__events.push('close'); });
+  document.addEventListener('keydown', e => { window.__key = e.key; });
+  d.showModal();
+  return d.open;
+})()
+"#,
+    )
+    .expect("modal dialog setup should evaluate");
+
+    vm.dispatch_key_event("keydown", "Escape", "Escape", "", 0, false, false)
+        .expect("Escape keydown should dispatch");
+
+    let result = vm
+        .eval(
+            r#"
+(() => JSON.stringify({
+  open: document.getElementById('modal').open,
+  key: window.__key,
+  events: window.__events
+}))()
+"#,
+        )
+        .expect("modal Escape result should evaluate");
+    let value: serde_json::Value = serde_json::from_str(&result).expect("json");
+    assert_eq!(value["open"], serde_json::json!(false));
+    assert_eq!(value["key"], serde_json::json!("Escape"));
+    assert!(
+        value["events"]
+            .as_array()
+            .expect("events array")
+            .contains(&serde_json::json!("cancel")),
+        "cancel must fire before Escape closes a modal dialog; got {result}"
+    );
+}
+
+#[test]
+fn dialog_escape_keydown_respects_prevent_default() {
+    let mut vm = new_storage_test_vm("https://dialog-escape-prevent-default.test/");
+
+    vm.eval(
+        r#"
+(() => {
+  const host = document.body || document.documentElement || document;
+  window.__cancels = [];
+  document.addEventListener('keydown', e => {
+    window.__key = e.key;
+    if (window.__blockEscape) { e.preventDefault(); }
+  });
+  function make(id, preventCancel) {
+    const d = document.createElement('dialog');
+    d.id = id;
+    host.appendChild(d);
+    if (preventCancel) {
+      d.addEventListener('cancel', e => { window.__cancels.push(id); e.preventDefault(); });
+    } else {
+      d.addEventListener('cancel', () => { window.__cancels.push(id); });
+    }
+    d.showModal();
+    return d;
+  }
+  window.__make = make;
+})()
+"#,
+    )
+    .expect("prevent-default dialog setup should evaluate");
+
+    // A keydown preventDefault suppresses the whole light-dismiss.
+    vm.eval("window.__blockEscape = true; window.__make('kd', false);")
+        .expect("blocked dialog");
+    vm.dispatch_key_event("keydown", "Escape", "Escape", "", 0, false, false)
+        .expect("blocked Escape keydown should dispatch");
+    let blocked = vm
+        .eval(
+            r#"(JSON.stringify({ open: document.getElementById('kd').open, cancels: window.__cancels }))"#,
+        )
+        .expect("blocked result should evaluate");
+    assert_eq!(
+        blocked, r#"{"open":true,"cancels":[]}"#,
+        "preventing the keydown must suppress the dialog light-dismiss"
+    );
+
+    // A cancel preventDefault fires cancel but keeps the dialog open.
+    vm.eval("window.__blockEscape = false; window.__make('cc', true);")
+        .expect("cancel-catch dialog");
+    vm.dispatch_key_event("keydown", "Escape", "Escape", "", 0, false, false)
+        .expect("cancel-caught Escape keydown should dispatch");
+    let cancel_caught = vm
+        .eval(
+            r#"(JSON.stringify({ open: document.getElementById('cc').open, cancels: window.__cancels }))"#,
+        )
+        .expect("cancel-caught result should evaluate");
+    assert_eq!(
+        cancel_caught, r#"{"open":true,"cancels":["cc"]}"#,
+        "a prevented cancel must keep the dialog open"
+    );
+}
+
+#[test]
+fn dialog_escape_keydown_does_not_close_non_modal_dialog() {
+    let mut vm = new_storage_test_vm("https://dialog-escape-non-modal.test/");
+
+    vm.eval(
+        r#"
+(() => {
+  const d = document.createElement('dialog');
+  d.id = 'plain';
+  (document.body || document.documentElement || document).appendChild(d);
+  window.__cancels = 0;
+  d.addEventListener('cancel', () => { window.__cancels += 1; });
+  d.show();
+  return d.open;
+})()
+"#,
+    )
+    .expect("non-modal dialog setup should evaluate");
+
+    vm.dispatch_key_event("keydown", "Escape", "Escape", "", 0, false, false)
+        .expect("Escape keydown should dispatch");
+
+    let result = vm
+        .eval(
+            r#"(JSON.stringify({ open: document.getElementById('plain').open, cancels: window.__cancels }))"#,
+        )
+        .expect("non-modal Escape result should evaluate");
+    assert_eq!(
+        result, r#"{"open":true,"cancels":0}"#,
+        "Escape must not light-dismiss a non-modal dialog"
+    );
+}


### PR DESCRIPTION
An open modal <dialog> was never closed by the Escape key: the keydown
reached document listeners but no default action ran, so dialog.open
stayed true and no cancel/close events fired. Add a trusted-keydown
default action that finds the topmost open modal dialog, fires a
cancelable cancel event, and closes it unless the event is canceled (or
the keydown itself was prevented). Non-modal dialogs are unaffected,
matching the spec.