### PR TITLE
refactor(v8): resolve intrinsic eval without compiling source

### DIFF
--- a/moli-renderer-v8/src/context_bootstrap/runtime_state.rs
+++ b/moli-renderer-v8/src/context_bootstrap/runtime_state.rs
@@ -2006,8 +2006,11 @@ fn install_window_runtime_state<'s>(
     // classic-script declarations like `var parent = ...` work, without letting
     // DOM named items shadow the builtins.
     WindowLegacyAliasAccessorsDeclaration::default().initialize(scope, global)?;
-    let intrinsic_eval = v8::Script::compile(scope, v8str(scope, "eval"), None)
-        .and_then(|script| script.run(scope))
+    // Read the existing V8 intrinsic without compiling a script or invoking
+    // Window's DOM named-property interceptors during bootstrap.
+    let intrinsic_eval = global
+        .get_real_named_property(scope, v8str(scope, "eval").into())
+        .filter(|value| value.is_function())
         .ok_or_else(|| anyhow!("failed to resolve intrinsic eval"))?;
     set_private_value(scope, global, WINDOW_INTRINSIC_EVAL_SLOT, intrinsic_eval);
     WindowEvalGlobalDeclaration::new(intrinsic_eval)

--- a/moli-renderer-v8/src/script_vm/tests/lazy_window_surfaces.rs
+++ b/moli-renderer-v8/src/script_vm/tests/lazy_window_surfaces.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod eval;
 mod rebind;
 mod seeds;
 

--- a/moli-renderer-v8/src/script_vm/tests/lazy_window_surfaces/eval.rs
+++ b/moli-renderer-v8/src/script_vm/tests/lazy_window_surfaces/eval.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+#[test]
+fn bootstrap_eval_remains_intrinsic_with_dom_named_candidates() {
+    let mut vm = new_parsed_test_vm(
+        "https://bootstrap-intrinsic-eval.test/",
+        "<!doctype html><body><div id=eval></div><form name=eval></form></body>",
+    );
+    assert_eq!(
+        vm.eval(
+            r#"(() => {
+                globalThis.__indirectEvalValue = 11;
+                function direct() {
+                    const lexicalValue = 7;
+                    return eval('lexicalValue + 1');
+                }
+                const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'eval');
+                return JSON.stringify([
+                    typeof eval, eval.name, eval.length, descriptor.value === eval,
+                    direct(), (0, eval)('__indirectEvalValue')
+                ]);
+            })()"#,
+        )
+        .expect("direct and indirect builtin eval with DOM named properties"),
+        r#"["function","eval",1,true,8,11]"#
+    );
+}


### PR DESCRIPTION
Read the existing intrinsic through V8 real-property lookup during Window bootstrap. Avoid one compile/run solely to retrieve eval and bypass DOM named-property interceptors. Cover direct and indirect eval with named DOM candidates. This is reduced bootstrap work, not a claimed MiB-scale steady-state memory saving.