### PR TITLE
fix(html): expose obsolete no-op methods

### DIFF
--- a/moli-renderer-v8/src/context_bootstrap/window_runtime.rs
+++ b/moli-renderer-v8/src/context_bootstrap/window_runtime.rs
@@ -4,6 +4,7 @@ mod base64;
 mod date_locale;
 mod dialogs;
 mod navigator;
+mod obsolete;
 mod performance;
 mod service_worker;
 mod structured_clone;
@@ -47,6 +48,7 @@ pub(super) use navigator::{
     storage_bucket_persist_callback, storage_bucket_persisted_callback,
     storage_bucket_set_expires_callback,
 };
+pub(super) use obsolete::window_obsolete_noop_callback;
 pub(super) use performance::performance_now_callback;
 pub(crate) use service_worker::{
     ServiceWorkerClientMessageCallbackDispatchEffect, ServiceWorkerClientMessageDispatchEffect,

--- a/moli-renderer-v8/src/context_bootstrap/window_runtime/obsolete.rs
+++ b/moli-renderer-v8/src/context_bootstrap/window_runtime/obsolete.rs
@@ -1,0 +1,31 @@
+use crate::util::{context_host_ptr_from_window_object, throw_type_error};
+
+fn receiver_is_window(
+    scope: &mut v8::PinScope<'_, '_>,
+    receiver: v8::Local<'_, v8::Object>,
+) -> bool {
+    if context_host_ptr_from_window_object(scope, receiver).is_none() {
+        return false;
+    }
+    let global = scope.get_current_context().global(scope);
+    if receiver.strict_equals(global.into()) {
+        return true;
+    }
+    receiver
+        .get_internal_field(scope, 1)
+        .and_then(|value| v8::Local::<v8::Value>::try_from(value).ok())
+        .and_then(|value| value.number_value(scope))
+        .is_some_and(|marker| marker.is_finite() && marker.fract() == 0.0 && marker == 0.0)
+}
+
+pub(in crate::context_bootstrap) fn window_obsolete_noop_callback<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    args: v8::FunctionCallbackArguments<'s>,
+    mut rv: v8::ReturnValue<'s, v8::Value>,
+) {
+    if !receiver_is_window(scope, args.this()) {
+        throw_type_error(scope, "Illegal invocation");
+        return;
+    }
+    rv.set_undefined();
+}

--- a/moli-renderer-v8/src/context_bootstrap/window_template.rs
+++ b/moli-renderer-v8/src/context_bootstrap/window_template.rs
@@ -83,6 +83,16 @@ struct WindowEarlyTemplateMethodsDeclaration {
 
 #[derive(WebApiFunctionTemplate)]
 #[webapi(name = "Window", enumerable)]
+struct WindowObsoleteTemplateMethodsDeclaration {
+    #[webapi(method, length = 0, callback = window_obsolete_noop_callback)]
+    capture_events: (),
+
+    #[webapi(method, length = 0, callback = window_obsolete_noop_callback)]
+    release_events: (),
+}
+
+#[derive(WebApiFunctionTemplate)]
+#[webapi(name = "Window", enumerable)]
 struct WindowPostNetworkTemplateMethodsDeclaration {
     #[webapi(
         method = "createImageBitmap",
@@ -335,6 +345,7 @@ pub(crate) fn install_window_own_template_bindings<'s>(
     // functions the actual WindowProxy as `this`.
     WindowIdentityAccessorsDeclaration::initialize_prototype_template(scope, window_template);
     WindowEarlyTemplateMethodsDeclaration::initialize_prototype_template(scope, window_template);
+    WindowObsoleteTemplateMethodsDeclaration::initialize_prototype_template(scope, window_template);
     network_host::install_window_network_bindings(scope, window_template);
     WindowPostNetworkTemplateMethodsDeclaration::initialize_prototype_template(
         scope,

--- a/moli-renderer-v8/src/native_bridge/document.rs
+++ b/moli-renderer-v8/src/native_bridge/document.rs
@@ -462,6 +462,17 @@ struct DocumentCollectionQueryPrototypeDeclaration {
 }
 
 #[derive(WebApiFunctionTemplate)]
+#[webapi(name = "Document", enumerable)]
+struct DocumentObsoleteMethodsPrototypeDeclaration {
+    #[webapi(method, length = 0, callback = document_obsolete_noop_callback)]
+    clear: (),
+    #[webapi(method, length = 0, callback = document_obsolete_noop_callback)]
+    capture_events: (),
+    #[webapi(method, length = 0, callback = document_obsolete_noop_callback)]
+    release_events: (),
+}
+
+#[derive(WebApiFunctionTemplate)]
 #[webapi(name = "DocumentFragment")]
 struct DocumentFragmentCollectionQueryPrototypeDeclaration {
     #[webapi(method, length = 1, callback = node_get_element_by_id_callback)]
@@ -505,6 +516,18 @@ fn document_receiver_runtime_and_handle<'s>(
         return None;
     }
     Some((runtime_ptr, handle))
+}
+
+fn document_obsolete_noop_callback<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    args: v8::FunctionCallbackArguments<'s>,
+    mut rv: v8::ReturnValue<'s, v8::Value>,
+) {
+    if document_receiver_runtime_and_handle(scope, args.this()).is_none() {
+        throw_type_error(scope, "Illegal invocation");
+        return;
+    }
+    rv.set_undefined();
 }
 
 fn set_document_string_return_value(
@@ -1340,6 +1363,9 @@ pub(crate) fn install_document_template_bindings<'s>(
             scope, prototype,
         );
         DocumentCollectionQueryPrototypeDeclaration::initialize_prototype_template(
+            scope, prototype,
+        );
+        DocumentObsoleteMethodsPrototypeDeclaration::initialize_prototype_template(
             scope, prototype,
         );
     }

--- a/moli-renderer-v8/src/script_vm/tests/dom_elements/detached.rs
+++ b/moli-renderer-v8/src/script_vm/tests/dom_elements/detached.rs
@@ -124,6 +124,69 @@ fn detached_document_write_preserves_existing_noscript_text() {
 }
 
 #[test]
+fn obsolete_document_and_window_event_methods_are_branded_noops() {
+    let mut vm = new_storage_test_vm("https://obsolete-noop-methods.test/");
+
+    let result = vm
+        .eval(
+            r#"
+(() => {
+  const html = document.implementation.createHTMLDocument("");
+  const xml = document.implementation.createDocument("urn:test", "root");
+  const marker = document.createElement("p");
+  const markerParent = document.body || document.documentElement || document;
+  markerParent.append(marker);
+  const error = callback => {
+    try {
+      callback();
+      return "none";
+    } catch (exception) {
+      return exception.name;
+    }
+  };
+  const shape = (prototype, name) => {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, name);
+    return [
+      typeof descriptor?.value,
+      descriptor?.value?.name,
+      descriptor?.value?.length,
+      descriptor?.writable,
+      descriptor?.enumerable,
+      descriptor?.configurable
+    ].join(":");
+  };
+
+  const values = [];
+  for (const name of ["clear", "captureEvents", "releaseEvents"]) {
+    values.push(shape(Document.prototype, name));
+    values.push(String(Document.prototype[name].call(document)));
+    values.push(String(Document.prototype[name].call(html, { ignored: true })));
+    values.push(String(Document.prototype[name].call(xml)));
+    values.push(error(() => Document.prototype[name].call({})));
+  }
+  for (const name of ["captureEvents", "releaseEvents"]) {
+    values.push(shape(window, name));
+    values.push(String(window[name].call(window, { ignored: true })));
+    values.push(error(() => window[name].call({})));
+    values.push(error(() => window[name].call(document)));
+    const forged = document.createElement("div");
+    Object.setPrototypeOf(forged, Window.prototype);
+    values.push(error(() => window[name].call(forged)));
+  }
+  values.push(String(marker.isConnected), String(markerParent.contains(marker)));
+  return values.join("|");
+})()
+"#,
+        )
+        .expect("obsolete Document and Window no-op methods should evaluate");
+
+    assert_eq!(
+        result,
+        "function:clear:0:true:true:true|undefined|undefined|undefined|TypeError|function:captureEvents:0:true:true:true|undefined|undefined|undefined|TypeError|function:releaseEvents:0:true:true:true|undefined|undefined|undefined|TypeError|function:captureEvents:0:true:true:true|undefined|TypeError|TypeError|TypeError|function:releaseEvents:0:true:true:true|undefined|TypeError|TypeError|TypeError|true|true"
+    );
+}
+
+#[test]
 fn detached_domparser_query_and_element_collections_use_native_handles() {
     let mut vm = new_storage_test_vm("https://detached-domparser-query.test/");
 


### PR DESCRIPTION
## Summary
- expose obsolete `Document` and `Window` event methods required by compatibility tests
- implement them as receiver-branded no-ops
- cover descriptors, detached documents, forged receivers, and lack of DOM side effects

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --no-fail-fast` (17117 passed, 13 skipped)