### PR TITLE
fix(html): implement writing suggestions semantics

### DIFF
--- a/moli-renderer-v8/src/native_bridge/element.rs
+++ b/moli-renderer-v8/src/native_bridge/element.rs
@@ -448,6 +448,7 @@ pub(super) use global_attributes::{
     node_spellcheck_setter_function, node_tab_index_getter_function,
     node_tab_index_setter_function, node_title_getter_function, node_title_setter_function,
     node_translate_getter_function, node_translate_setter_function,
+    node_writing_suggestions_getter_function, node_writing_suggestions_setter_function,
     null_to_empty_dom_string_reflection_setter_function, object_archive_getter_function,
     object_code_base_getter_function, object_code_getter_function,
     object_code_type_getter_function, object_data_getter_function, object_declare_getter_function,
@@ -1482,6 +1483,13 @@ struct HtmlElementStandardPrototypeDeclaration {
         setter = node_spellcheck_setter_function
     )]
     spellcheck: (),
+    #[webapi(
+        accessor_property = "writingSuggestions",
+        enumerable,
+        getter = node_writing_suggestions_getter_function,
+        setter = node_writing_suggestions_setter_function
+    )]
+    writing_suggestions: (),
     #[webapi(
         accessor_property = "contentEditable",
         enumerable,

--- a/moli-renderer-v8/src/native_bridge/element/global_attributes.rs
+++ b/moli-renderer-v8/src/native_bridge/element/global_attributes.rs
@@ -2161,6 +2161,85 @@ pub(in crate::native_bridge) fn node_spellcheck_setter_function<'s>(
     rv.set_undefined();
 }
 
+fn computed_writing_suggestions_value(runtime: &JsContextHost, handle: DomHandle) -> &'static str {
+    let mut current = Some(handle);
+    while let Some(candidate) = current {
+        if let Some(value) = runtime
+            .dom_host()
+            .node(candidate)
+            .and_then(Node::as_element)
+            .and_then(|element| element.attribute_ns("", "writingsuggestions"))
+        {
+            return if value.eq_ignore_ascii_case("false") {
+                "false"
+            } else {
+                "true"
+            };
+        }
+        current = runtime.dom_host().parent_node(candidate);
+    }
+    "true"
+}
+
+pub(in crate::native_bridge) fn node_writing_suggestions_getter_function<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    args: v8::FunctionCallbackArguments<'s>,
+    mut rv: v8::ReturnValue<'s, v8::Value>,
+) {
+    let Ok((runtime_ptr, handle)) =
+        node_runtime_and_handle_from_object_or_detached(scope, args.this())
+    else {
+        throw_incompatible_getter_receiver(scope, "HTMLElement", "writingSuggestions");
+        return;
+    };
+    let runtime = unsafe { &*runtime_ptr };
+    let is_html_element = runtime
+        .dom_host()
+        .node(handle)
+        .and_then(Node::as_element)
+        .is_some_and(|element| element.namespace() == "http://www.w3.org/1999/xhtml");
+    if !is_html_element {
+        throw_incompatible_getter_receiver(scope, "HTMLElement", "writingSuggestions");
+        return;
+    }
+
+    let value = computed_writing_suggestions_value(runtime, handle);
+    let Some(value) = v8_string(scope, value) else {
+        rv.set_empty_string();
+        return;
+    };
+    rv.set(value.into());
+}
+
+pub(in crate::native_bridge) fn node_writing_suggestions_setter_function<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    args: v8::FunctionCallbackArguments<'s>,
+    mut rv: v8::ReturnValue<'s, v8::Value>,
+) {
+    let Ok((runtime_ptr, handle)) =
+        node_runtime_and_handle_from_object_or_detached(scope, args.this())
+    else {
+        throw_incompatible_setter_receiver(scope, "HTMLElement", "writingSuggestions");
+        return;
+    };
+    let is_html_element = unsafe { &*runtime_ptr }
+        .dom_host()
+        .node(handle)
+        .and_then(Node::as_element)
+        .is_some_and(|element| element.namespace() == "http://www.w3.org/1999/xhtml");
+    if !is_html_element {
+        throw_incompatible_setter_receiver(scope, "HTMLElement", "writingSuggestions");
+        return;
+    }
+    let Some(value) =
+        property_dom_string_value(scope, args.get(0), "HTMLElement", "writingSuggestions")
+    else {
+        return;
+    };
+    set_reflected_attribute(scope, runtime_ptr, handle, "writingsuggestions", &value);
+    rv.set_undefined();
+}
+
 fn set_keyword_attribute_from_boolean_on_object<'s>(
     scope: &mut v8::PinScope<'s, '_>,
     object: v8::Local<'s, v8::Object>,

--- a/moli-renderer-v8/src/script_vm/tests/dom_elements/detached.rs
+++ b/moli-renderer-v8/src/script_vm/tests/dom_elements/detached.rs
@@ -2676,6 +2676,7 @@ fn detached_global_html_attributes_use_html_element_prototype_accessors() {
     "accessKey",
     "draggable",
     "spellcheck",
+    "writingSuggestions",
     "enterKeyHint",
     "inputMode",
     "autofocus",
@@ -2702,6 +2703,7 @@ fn detached_global_html_attributes_use_html_element_prototype_accessors() {
     descriptors.translate.set.call(element, false);
     descriptors.draggable.set.call(element, true);
     descriptors.spellcheck.set.call(element, false);
+    descriptors.writingSuggestions.set.call(element, false);
     descriptors.tabIndex.set.call(element, 7);
 
     assert(descriptors.title.get.call(element) === "Title", `${label}.title`);
@@ -2717,10 +2719,12 @@ fn detached_global_html_attributes_use_html_element_prototype_accessors() {
     assert(descriptors.translate.get.call(element) === false, `${label}.translate`);
     assert(descriptors.draggable.get.call(element) === true, `${label}.draggable`);
     assert(descriptors.spellcheck.get.call(element) === false, `${label}.spellcheck`);
+    assert(descriptors.writingSuggestions.get.call(element) === "false", `${label}.writingSuggestions`);
     assert(descriptors.tabIndex.get.call(element) === 7, `${label}.tabIndex`);
     assert(element.getAttribute("translate") === "no", `${label}.translate attr`);
     assert(element.getAttribute("draggable") === "true", `${label}.draggable attr`);
     assert(element.getAttribute("spellcheck") === "false", `${label}.spellcheck attr`);
+    assert(element.getAttribute("writingsuggestions") === "false", `${label}.writingsuggestions attr`);
     assert(element.getAttribute("tabindex") === "7", `${label}.tabindex attr`);
 
     descriptors.hidden.set.call(element, false);

--- a/moli-renderer-v8/src/script_vm/tests/dom_elements/dom_surface.rs
+++ b/moli-renderer-v8/src/script_vm/tests/dom_elements/dom_surface.rs
@@ -3348,6 +3348,97 @@ fn autocorrect_reflects_boolean_and_inherits_from_form_owner() {
 }
 
 #[test]
+fn writing_suggestions_reflects_and_inherits_nearest_ancestor_state() {
+    let mut vm = new_parsed_test_vm(
+        "https://writing-suggestions.test/",
+        "<!doctype html><html><body></body></html>",
+    );
+
+    let result = vm
+        .eval(
+            r#"
+(() => {
+  const parent = document.createElement('section');
+  const child = document.createElement('div');
+  const grandchild = document.createElement('span');
+  parent.append(child);
+  child.append(grandchild);
+  parent.setAttribute('writingsuggestions', 'FaLsE');
+
+  const inherited = [
+    parent.writingSuggestions,
+    child.writingSuggestions,
+    grandchild.writingSuggestions
+  ];
+  child.setAttribute('writingsuggestions', '');
+  const emptyOverride = [child.writingSuggestions, grandchild.writingSuggestions];
+  child.setAttribute('writingsuggestions', 'invalid');
+  const invalidOverride = [child.writingSuggestions, grandchild.writingSuggestions];
+  child.removeAttribute('writingsuggestions');
+  const restoredInheritance = grandchild.writingSuggestions;
+
+  grandchild.writingSuggestions = false;
+  const booleanSetter = [
+    grandchild.writingSuggestions,
+    grandchild.getAttribute('writingsuggestions')
+  ];
+  grandchild.writingSuggestions = { toString() { return 'TrUe'; } };
+  const domStringSetter = [
+    grandchild.writingSuggestions,
+    grandchild.getAttribute('writingsuggestions')
+  ];
+
+  const namespaceOnly = document.createElement('div');
+  namespaceOnly.setAttributeNS('urn:test', 'writingsuggestions', 'false');
+
+  const detachedParent = document.createElement('div');
+  const detachedChild = document.createElement('span');
+  detachedParent.setAttribute('writingsuggestions', 'false');
+  detachedParent.append(detachedChild);
+
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'writingSuggestions'
+  );
+  const incompatible = operation => {
+    try {
+      operation(document.createElementNS('urn:test', 'div'));
+      return 'none';
+    } catch (error) {
+      return error.name;
+    }
+  };
+
+  return JSON.stringify({
+    descriptor: [descriptor.enumerable, descriptor.configurable],
+    inherited,
+    emptyOverride,
+    invalidOverride,
+    restoredInheritance,
+    booleanSetter,
+    domStringSetter,
+    namespaceOnly: [
+      namespaceOnly.writingSuggestions,
+      namespaceOnly.getAttribute('writingsuggestions')
+    ],
+    detached: detachedChild.writingSuggestions,
+    incompatible: [
+      incompatible(receiver => descriptor.get.call(receiver)),
+      incompatible(receiver => descriptor.set.call(receiver, 'false'))
+    ]
+  });
+})()
+"#,
+        )
+        .expect("writingSuggestions semantics should evaluate");
+
+    assert_eq!(
+        result,
+        r#"{"descriptor":[true,true],"inherited":["false","false","false"],"emptyOverride":["true","true"],"invalidOverride":["true","true"],"restoredInheritance":"false","booleanSetter":["false","false"],"domStringSetter":["true","TrUe"],"namespaceOnly":["true","false"],"detached":"false","incompatible":["TypeError","TypeError"]}"#
+    );
+}
+
+#[test]
 fn set_range_text_preserve_mode_adjusts_selection_by_replacement_delta() {
     let mut vm = new_storage_test_vm("https://forms-selection-set-range-text.test/");
 

--- a/moli-renderer-v8/src/script_vm/tests/dom_elements/live_document.rs
+++ b/moli-renderer-v8/src/script_vm/tests/dom_elements/live_document.rs
@@ -718,6 +718,7 @@ fn htmlelement_standard_accessors_live_on_owner_prototypes() {
                 "accessKey",
                 "draggable",
                 "spellcheck",
+                "writingSuggestions",
                 "contentEditable",
                 "enterKeyHint",
                 "isContentEditable",
@@ -760,6 +761,7 @@ fn htmlelement_standard_accessors_live_on_owner_prototypes() {
               div.accessKey = "x";
               div.draggable = true;
               div.spellcheck = false;
+              div.writingSuggestions = false;
               div.contentEditable = "plaintext-only";
               div.enterKeyHint = "Go";
               div.inputMode = "NUMERIC";
@@ -778,6 +780,7 @@ fn htmlelement_standard_accessors_live_on_owner_prototypes() {
               assert(div.accessKey === "x", "accessKey behavior");
               assert(div.draggable === true && div.getAttribute("draggable") === "true", "draggable behavior");
               assert(div.spellcheck === false && div.getAttribute("spellcheck") === "false", "spellcheck behavior");
+              assert(div.writingSuggestions === "false" && div.getAttribute("writingsuggestions") === "false", "writingSuggestions behavior");
               assert(div.contentEditable === "plaintext-only" && div.isContentEditable === true, "contentEditable behavior");
               assert(div.enterKeyHint === "go", "enterKeyHint behavior");
               assert(div.inputMode === "numeric", "inputMode behavior");


### PR DESCRIPTION
## Summary
- expose `HTMLElement.writingSuggestions`
- compute the inherited state from the nearest HTML ancestor
- preserve Web IDL string conversion and HTML receiver branding
- cover live, detached, namespace, and prototype behavior

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --no-fail-fast` (17117 passed, 13 skipped)