### PR TITLE
fix(popovers): preserve flat-tree ancestor stacks

### DIFF
--- a/moli-renderer-v8/src/native_bridge/element/popover.rs
+++ b/moli-renderer-v8/src/native_bridge/element/popover.rs
@@ -307,6 +307,44 @@ fn shadow_including_tree_contains(
     }
 }
 
+fn popover_flat_tree_contains(
+    runtime: &JsContextHost,
+    ancestor: DomHandle,
+    handle: DomHandle,
+) -> bool {
+    let mut current = Some(handle);
+    while let Some(candidate) = current {
+        if candidate == ancestor {
+            return true;
+        }
+        current = popover_flat_tree_parent(runtime, candidate);
+    }
+    false
+}
+
+fn popover_flat_tree_parent(runtime: &JsContextHost, handle: DomHandle) -> Option<DomHandle> {
+    if let Some(slot) = runtime.dom_host().assigned_slot_for_node(handle) {
+        return Some(slot);
+    }
+    let parent = runtime.dom_host().parent_node(handle)?;
+    if runtime.dom_host().is_shadow_root(parent) {
+        return runtime.dom_host().shadow_root_host(parent);
+    }
+    if runtime.dom_host().shadow_root_handle(parent).is_some() {
+        return None;
+    }
+    if runtime.dom_host().is_html_element_named(parent, "slot")
+        && runtime.dom_host().containing_shadow_root(parent).is_some()
+        && !runtime
+            .dom_host()
+            .assigned_nodes_for_slot_with_options(parent, false)
+            .is_empty()
+    {
+        return None;
+    }
+    Some(parent)
+}
+
 fn close_open_auto_popovers(
     scope: &mut v8::PinScope<'_, '_>,
     runtime_ptr: *mut JsContextHost,
@@ -325,7 +363,9 @@ fn close_open_auto_popovers(
         if !popover_is_open(runtime, candidate) {
             continue;
         }
-        if source.is_some_and(|source| runtime.dom_host().dom().contains(candidate, source)) {
+        if popover_flat_tree_contains(runtime, candidate, opening)
+            || source.is_some_and(|source| popover_flat_tree_contains(runtime, candidate, source))
+        {
             continue;
         }
         let _ = set_popover_open_state(scope, runtime_ptr, candidate, false, None);

--- a/moli-renderer-v8/src/script_vm/tests/browser_api/misc.rs
+++ b/moli-renderer-v8/src/script_vm/tests/browser_api/misc.rs
@@ -5775,6 +5775,87 @@ fn show_and_hide_popover_throw_on_redundant_state_changes() {
 }
 
 #[test]
+fn opening_auto_popovers_preserves_flat_tree_ancestors() {
+    let mut vm = new_storage_test_vm("https://popover-flat-tree-ancestors.test/");
+
+    let result = vm
+        .eval(
+            r#"
+            (() => {
+              const html = document.appendChild(document.createElement("html"));
+              const body = html.appendChild(document.createElement("body"));
+              const outer = document.createElement("div");
+              const middle = document.createElement("div");
+              const inner = document.createElement("div");
+              const unrelated = document.createElement("div");
+              for (const popover of [outer, middle, inner, unrelated]) {
+                popover.popover = "auto";
+              }
+              outer.appendChild(middle).appendChild(inner);
+              body.append(outer, unrelated);
+
+              outer.showPopover();
+              middle.showPopover();
+              inner.showPopover();
+              const nested = [outer, middle, inner].map(popover =>
+                popover.matches(":popover-open")
+              );
+
+              unrelated.showPopover();
+              const unrelatedClosesStack = [outer, middle, inner, unrelated].map(popover =>
+                popover.matches(":popover-open")
+              );
+
+              unrelated.hidePopover();
+              const sourceOwner = document.createElement("div");
+              const sourceHost = document.createElement("span");
+              const sourced = document.createElement("div");
+              sourceOwner.popover = "auto";
+              sourced.popover = "auto";
+              const source = sourceHost
+                .attachShadow({ mode: "open" })
+                .appendChild(document.createElement("button"));
+              sourceOwner.appendChild(sourceHost);
+              body.append(sourceOwner, sourced);
+              sourceOwner.showPopover();
+              sourced.showPopover({ source });
+              const shadowSource = [sourceOwner, sourced].map(popover =>
+                popover.matches(":popover-open")
+              );
+
+              sourced.hidePopover();
+              sourceOwner.hidePopover();
+              const shadowHost = document.createElement("div");
+              const unassigned = document.createElement("div");
+              shadowHost.popover = "auto";
+              unassigned.popover = "auto";
+              shadowHost.appendChild(unassigned);
+              shadowHost.attachShadow({ mode: "open" }).innerHTML = "<span></span>";
+              body.appendChild(shadowHost);
+              shadowHost.showPopover();
+              unassigned.showPopover();
+              const unassignedLightChild = [shadowHost, unassigned].map(popover =>
+                popover.matches(":popover-open")
+              );
+
+              return JSON.stringify({
+                nested,
+                unrelatedClosesStack,
+                shadowSource,
+                unassignedLightChild
+              });
+            })()
+            "#,
+        )
+        .expect("popover flat-tree ancestor probe should evaluate");
+
+    assert_eq!(
+        result,
+        r#"{"nested":[true,true,true],"unrelatedClosesStack":[false,false,false,true],"shadowSource":[true,true],"unassignedLightChild":[false,true]}"#
+    );
+}
+
+#[test]
 fn stale_popover_element_matches_false_after_document_open_replacement() {
     let mut vm = new_storage_test_vm("https://popover-document-open.test/");
 


### PR DESCRIPTION
## Summary
- use flat-tree ancestry when deciding which auto popovers remain open
- preserve nested stacks across slots and shadow roots
- close unrelated stacks and reject unassigned light children as ancestors

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --no-fail-fast` (17117 passed, 13 skipped)