### PR TITLE
fix(window): validate scheduled callback cancellation

### DIFF
--- a/moli-renderer-v8/src/context_bootstrap/window_template.rs
+++ b/moli-renderer-v8/src/context_bootstrap/window_template.rs
@@ -132,7 +132,7 @@ struct WindowPostNetworkTemplateMethodsDeclaration {
     #[webapi(
         method,
         length = 1,
-        callback = window_host::window_clear_timer_callback
+        callback = window_host::window_cancel_animation_frame_callback
     )]
     cancel_animation_frame: (),
 
@@ -146,7 +146,7 @@ struct WindowPostNetworkTemplateMethodsDeclaration {
     #[webapi(
         method,
         length = 1,
-        callback = window_host::window_clear_timer_callback
+        callback = window_host::window_cancel_idle_callback
     )]
     cancel_idle_callback: (),
 

--- a/moli-renderer-v8/src/script_vm/tests/browser_api/idle_callbacks.rs
+++ b/moli-renderer-v8/src/script_vm/tests/browser_api/idle_callbacks.rs
@@ -311,3 +311,45 @@ fn animation_frame_and_idle_callbacks_require_callable_webidl_values() {
         "TypeError|TypeError"
     );
 }
+
+#[test]
+fn animation_frame_and_idle_cancellation_use_required_unsigned_long_handles() {
+    let mut vm = new_storage_test_vm("https://window-cancel-callback-conversion.test/");
+    assert_eq!(
+        vm.eval(
+            r#"
+            (() => {
+              const probe = callback => {
+                try {
+                  return `return:${String(callback())}`;
+                } catch (error) {
+                  return `throw:${error && error.name}`;
+                }
+              };
+              const facts = {};
+              for (const [label, cancel] of [
+                ["animation", cancelAnimationFrame],
+                ["idle", cancelIdleCallback]
+              ]) {
+                let conversions = 0;
+                facts[label] = {
+                  missing: probe(() => cancel.call(window)),
+                  wrongReceiver: probe(() => cancel.call({}, 0)),
+                  symbol: probe(() => cancel.call(window, Symbol("handle"))),
+                  object: probe(() => cancel.call(window, {
+                    valueOf() {
+                      conversions++;
+                      return 0;
+                    }
+                  })),
+                  conversions
+                };
+              }
+              return JSON.stringify(facts);
+            })()
+            "#,
+        )
+        .expect("Window cancellation callback Web IDL conversion result"),
+        r#"{"animation":{"missing":"throw:TypeError","wrongReceiver":"throw:TypeError","symbol":"throw:TypeError","object":"return:undefined","conversions":1},"idle":{"missing":"throw:TypeError","wrongReceiver":"throw:TypeError","symbol":"throw:TypeError","object":"return:undefined","conversions":1}}"#
+    );
+}

--- a/moli-renderer-v8/src/window_host.rs
+++ b/moli-renderer-v8/src/window_host.rs
@@ -114,6 +114,20 @@ struct WindowRequestIdleCallbackArgs<'s> {
     options: Option<v8::Local<'s, v8::Value>>,
 }
 
+#[derive(webidl::WebIdlArgs)]
+#[webidl(prefix = "Window.cancelAnimationFrame")]
+struct WindowCancelAnimationFrameArgs {
+    #[webidl(required, converter = "unsigned_long")]
+    handle: u32,
+}
+
+#[derive(webidl::WebIdlArgs)]
+#[webidl(prefix = "Window.cancelIdleCallback")]
+struct WindowCancelIdleCallbackArgs {
+    #[webidl(required, converter = "unsigned_long")]
+    handle: u32,
+}
+
 #[derive(WebApiFunctionTemplate)]
 #[webapi(name = "IdleDeadline", enumerable)]
 struct IdleDeadlinePrototypeDeclaration {
@@ -711,16 +725,54 @@ pub(super) fn window_clear_timer_callback<'s>(
     args: v8::FunctionCallbackArguments<'s>,
     _rv: v8::ReturnValue<'_, v8::Value>,
 ) {
-    let Some(host_ptr) = context_host_ptr_from_global_bridge(scope) else {
-        return;
-    };
     let id_val = args.get(0);
     let id = id_val.number_value(scope).unwrap_or(0.0) as u32;
+    cancel_window_timer_for_receiver(scope, args.this(), id);
+}
+
+pub(super) fn window_cancel_animation_frame_callback<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    args: v8::FunctionCallbackArguments<'s>,
+    _rv: v8::ReturnValue<'_, v8::Value>,
+) {
+    if !crate::context_bootstrap::is_window_receiver(scope, args.this()) {
+        throw_type_error(scope, "Illegal invocation");
+        return;
+    }
+    let Some(parsed) = webidl::parse_args::<WindowCancelAnimationFrameArgs>(scope, &args) else {
+        return;
+    };
+    cancel_window_timer_for_receiver(scope, args.this(), parsed.handle);
+}
+
+pub(super) fn window_cancel_idle_callback<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    args: v8::FunctionCallbackArguments<'s>,
+    _rv: v8::ReturnValue<'_, v8::Value>,
+) {
+    if !crate::context_bootstrap::is_window_receiver(scope, args.this()) {
+        throw_type_error(scope, "Illegal invocation");
+        return;
+    }
+    let Some(parsed) = webidl::parse_args::<WindowCancelIdleCallbackArgs>(scope, &args) else {
+        return;
+    };
+    cancel_window_timer_for_receiver(scope, args.this(), parsed.handle);
+}
+
+fn cancel_window_timer_for_receiver<'s>(
+    scope: &mut v8::PinScope<'s, '_>,
+    receiver: v8::Local<'s, v8::Object>,
+    id: u32,
+) {
     if id == 0 {
         return;
     }
+    let Some(host_ptr) = context_host_ptr_from_global_bridge(scope) else {
+        return;
+    };
     let runtime = unsafe { &mut *host_ptr };
-    let _ = runtime.cancel_window_timer_for_receiver(scope, args.this(), id);
+    let _ = runtime.cancel_window_timer_for_receiver(scope, receiver, id);
 }
 
 pub(super) fn window_request_animation_frame_callback<'s>(


### PR DESCRIPTION
## Summary
- give `cancelAnimationFrame` and `cancelIdleCallback` dedicated Web IDL callbacks
- require and convert unsigned-long handles
- enforce Window receiver branding while reusing the existing timer cancellation path

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- full test suite delegated to CI