### PR TITLE
fix(dom): stop exposing removed DOMError

### DIFF
--- a/moli-renderer-v8/src/context_bootstrap/assets/global.rs
+++ b/moli-renderer-v8/src/context_bootstrap/assets/global.rs
@@ -1,7 +1,7 @@
 use super::super::shared::define_global_template_value;
 use super::super::{
     exposed_interfaces::{
-        ExposedInterfaceTemplateRegistry, TemplateBuildProfile, constructor_spec_is_lazy,
+        ExposedInterfaceTemplateRegistry, TemplateBuildProfile, constructor_spec_is_eager,
         install_window_exposed_interfaces,
     },
     specs::constructor_specs,
@@ -59,7 +59,7 @@ impl ContextBootstrapAssets {
 
         install_window_exposed_interfaces(scope, global_template, &registry)?;
         for spec in &constructor_specs {
-            if constructor_spec_is_lazy(*spec) {
+            if !constructor_spec_is_eager(*spec) {
                 continue;
             }
             let id = registry

--- a/moli-renderer-v8/src/context_bootstrap/exposed_interfaces/metadata.rs
+++ b/moli-renderer-v8/src/context_bootstrap/exposed_interfaces/metadata.rs
@@ -122,6 +122,7 @@ pub(crate) fn dedicated_worker_lazy_interface_names_for_test() -> Vec<&'static s
 /// `Window` owns the concrete global template and its prototype is needed
 /// while the realm's named-properties chain is assembled.
 const EAGER_INTERFACE_NAMES: &[&str] = &["Window"];
+const NON_EXPOSED_INTERFACE_NAMES: &[&str] = &["DOMError"];
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct InterfaceId(u32);
@@ -256,9 +257,7 @@ impl ExposedInterfaceMetadata {
     }
 
     pub(super) fn is_supported_by(self, profile: TemplateBuildProfile) -> bool {
-        self.installation != GlobalInstallation::NotExposed
-            && self.exposure.contains(profile.realm_kind())
-            && profile.supports_name(self.name)
+        self.exposure.contains(profile.realm_kind()) && profile.supports_name(self.name)
     }
 }
 
@@ -351,7 +350,9 @@ impl ExposedInterfaceMetadataTable {
 }
 
 pub(super) fn installation_for_spec(spec: ConstructorSpec) -> GlobalInstallation {
-    if EAGER_INTERFACE_NAMES.contains(&spec.name) {
+    if NON_EXPOSED_INTERFACE_NAMES.contains(&spec.name) {
+        GlobalInstallation::NotExposed
+    } else if EAGER_INTERFACE_NAMES.contains(&spec.name) {
         GlobalInstallation::Eager
     } else {
         GlobalInstallation::Lazy
@@ -379,8 +380,8 @@ fn exposure_for_name(name: &str) -> ExposureSet {
     }
 }
 
-pub(in crate::context_bootstrap) fn constructor_spec_is_lazy(spec: ConstructorSpec) -> bool {
-    installation_for_spec(spec) == GlobalInstallation::Lazy
+pub(in crate::context_bootstrap) fn constructor_spec_is_eager(spec: ConstructorSpec) -> bool {
+    installation_for_spec(spec) == GlobalInstallation::Eager
 }
 
 fn validate_materialization_cycles(entries: &[ExposedInterfaceMetadata]) -> Result<()> {
@@ -570,6 +571,7 @@ mod tests {
         let table = ExposedInterfaceMetadataTable::from_constructor_specs(&[
             spec("Event", None),
             spec("Window", None),
+            spec("DOMError", None),
             ConstructorSpec {
                 name: "Audio",
                 parent: None,
@@ -600,6 +602,12 @@ mod tests {
                 .installation,
             GlobalInstallation::Lazy
         );
+        let dom_error = table
+            .metadata_by_name("DOMError")
+            .expect("DOMError metadata");
+        assert_eq!(dom_error.installation, GlobalInstallation::NotExposed);
+        assert!(!dom_error.is_exposed(RealmKind::Window, true));
+        assert!(dom_error.is_supported_by(TemplateBuildProfile::Window));
     }
 
     #[test]

--- a/moli-renderer-v8/src/context_bootstrap/exposed_interfaces/mod.rs
+++ b/moli-renderer-v8/src/context_bootstrap/exposed_interfaces/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use materialize::{
 };
 pub(crate) use metadata::RealmKind;
 pub(in crate::context_bootstrap) use metadata::TemplateBuildProfile;
-pub(super) use metadata::constructor_spec_is_lazy;
+pub(super) use metadata::constructor_spec_is_eager;
 #[cfg(test)]
 pub(crate) use metadata::dedicated_worker_lazy_interface_names_for_test;
 pub(in crate::context_bootstrap) use template_registry::ExposedInterfaceTemplateRegistry;

--- a/moli-renderer-v8/src/context_bootstrap/runtime_state.rs
+++ b/moli-renderer-v8/src/context_bootstrap/runtime_state.rs
@@ -1678,7 +1678,6 @@ pub(crate) fn finish_context_bootstrap(
         ("NamedNodeMap", "NamedNodeMap"),
         ("HTMLAllCollection", "HTMLAllCollection"),
         ("DOMException", "DOMException"),
-        ("DOMError", "DOMError"),
         ("DocumentType", "DocumentType"),
         ("DOMImplementation", "DOMImplementation"),
         ("DOMTokenList", "DOMTokenList"),

--- a/moli-renderer-v8/src/runtime/page_vm/tests/misc_platform_api.rs
+++ b/moli-renderer-v8/src/runtime/page_vm/tests/misc_platform_api.rs
@@ -390,18 +390,15 @@ async fn deprecated_storage_quota_reports_opaque_origin_errors_asynchronously() 
             page_vm.vm_mut().eval(
                 r#"
 {
-  const error = new DOMError("LegacyName", "legacy message");
   [
-    Object.prototype.toString.call(error),
-    error.name,
-    error.message,
-    error instanceof DOMError,
+    "DOMError" in globalThis,
+    typeof DOMError,
   ].join("|")
 }
 "#,
             )?,
-            "[object DOMError]|LegacyName|legacy message|true",
-            "the legacy callback error type must retain its Chromium-compatible interface identity"
+            "false|undefined",
+            "the removed DOMError interface must not remain globally exposed"
         );
         assert_eq!(
             page_vm.vm_mut().eval(
@@ -415,8 +412,8 @@ navigator.webkitTemporaryStorage.queryUsageAndQuota(
       __legacyQuotaOpaqueEvents.push(
         `error:${this === undefined}:${arguments.length}:` +
         `${error.name}:${Object.prototype.toString.call(error)}:` +
-        `${error instanceof DOMError}:${error instanceof DOMException}:` +
-        `${error.constructor === DOMError}:${error.message}`
+        `${error instanceof DOMException}:${error.constructor.name}:` +
+        `${error.message}:${"DOMError" in globalThis}:${typeof DOMError}`
       );
       Promise.resolve().then(() => {
         __legacyQuotaOpaqueEvents.push("microtask:error");
@@ -459,7 +456,7 @@ JSON.stringify(__legacyQuotaOpaqueEvents)
             page_vm
                 .vm_mut()
                 .eval("__legacyQuotaOpaqueEvents.join('|')")?,
-            "apply:true:1|error:true:1:NotSupportedError:[object DOMError]:true:false:true:The implementation did not support the requested type of object or operation.|microtask:error"
+            "apply:true:1|error:true:1:NotSupportedError:[object DOMError]:false:DOMError:The implementation did not support the requested type of object or operation.:false:undefined|microtask:error"
         );
         Ok::<_, anyhow::Error>(())
     })


### PR DESCRIPTION
## Summary
- mark `DOMError` as a non-exposed interface
- skip installing its global constructor while retaining internal legacy error objects
- verify deprecated quota callbacks still carry compatible identity without a page-visible global

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- full test suite delegated to CI