### PR TITLE
test(worker): queue port messages before receiver transfer

### DIFF
--- a/moli-renderer-v8/src/runtime/page_vm/tests/worker.rs
+++ b/moli-renderer-v8/src/runtime/page_vm/tests/worker.rs
@@ -7904,22 +7904,22 @@ async fn worker_messageport_close_preserves_same_task_queued_messages() {
                                       postMessage(messages.join('|'));
                                     }
                                   };
-                                  postMessage('ready');
                                 };
                                 `)
                             );
                             const channel = new MessageChannel();
                             worker.onmessage = (event) => {
-                                if (event.data === 'ready') {
-                                    channel.port1.postMessage('first');
-                                    channel.port1.postMessage('second');
-                                    return;
-                                }
                                 globalThis.__messagePortCloseRaceResult = event.data;
                                 worker.terminate();
                                 channel.port1.close();
                                 globalThis.__messagePortCloseRaceDone = true;
                             };
+                            // Queue both messages before transferring the receiving
+                            // port. One task on this agent does not stop the worker
+                            // from handling 'first' and closing an already-transferred
+                            // port before 'second' is enqueued.
+                            channel.port1.postMessage('first');
+                            channel.port1.postMessage('second');
                             worker.postMessage('connect', [channel.port2]);
                         })()
                         "#,


### PR DESCRIPTION
Two postMessage calls in one parent task do not prevent the independent worker from closing the receiver between them. Queue both messages before transferring the receiver so this test actually exercises delivery of messages already queued at close.

Keep the strict first|second result and existing deadline without sleeps, retries, or production changes. Verified with 50 focused iterations, three complete worker-module iterations, and two full nextest runs.