### PR TITLE
fix(renderer): share and bound worker wake routes

### DIFF
--- a/moli-renderer-v8/src/lib.rs
+++ b/moli-renderer-v8/src/lib.rs
@@ -113,6 +113,7 @@ mod window_document_identity;
 mod window_host;
 mod window_webidl_callback;
 pub(crate) mod worker;
+mod worker_owner_wake;
 mod xml_serializer;
 
 pub(crate) mod planning {

--- a/moli-renderer-v8/src/runtime/browser_context_runtime/service_worker_runtime.rs
+++ b/moli-renderer-v8/src/runtime/browser_context_runtime/service_worker_runtime.rs
@@ -8,9 +8,10 @@ use crate::{
     runtime::{RendererRuntimeInspectorMessage, RendererRuntimeInspectorResponseSender},
     service_worker_runtime::{
         ServiceWorkerClientFrameType, ServiceWorkerClientId, ServiceWorkerRegistrationId,
-        ServiceWorkerRuntimeOwnerWakeSender, ServiceWorkerVersionId,
+        ServiceWorkerRuntimeOwnerWake, ServiceWorkerRuntimeOwnerWakeSender, ServiceWorkerVersionId,
     },
     window_document_identity::WindowDocumentOwner,
+    worker_owner_wake::WorkerOwnerWakeRoutes,
 };
 
 use super::RendererBrowserContextRuntime;
@@ -29,7 +30,7 @@ pub(super) struct LazyServiceWorkerRuntime {
 
 enum LazyServiceWorkerRuntimeState {
     Deferred {
-        owner_wake_senders: Vec<ServiceWorkerRuntimeOwnerWakeSender>,
+        owner_wake_senders: WorkerOwnerWakeRoutes<ServiceWorkerRuntimeOwnerWake>,
         window_clients: HashMap<ServiceWorkerClientId, DeferredServiceWorkerWindowClient>,
         force_update_on_page_load: bool,
         pause_new_workers_on_start: bool,
@@ -64,7 +65,7 @@ impl LazyServiceWorkerRuntime {
     ) -> Self {
         Self {
             state: Mutex::new(LazyServiceWorkerRuntimeState::Deferred {
-                owner_wake_senders: Vec::new(),
+                owner_wake_senders: WorkerOwnerWakeRoutes::default(),
                 window_clients: HashMap::new(),
                 force_update_on_page_load: false,
                 pause_new_workers_on_start: false,
@@ -108,7 +109,7 @@ impl LazyServiceWorkerRuntime {
                 self.browser_context_runtime_id,
                 self.output_transport.clone(),
             );
-        for sender in owner_wake_senders {
+        for sender in owner_wake_senders.into_senders() {
             service.add_owner_wake_sender(sender);
         }
         service.set_force_update_on_page_load_for_devtools(force_update_on_page_load);
@@ -277,7 +278,7 @@ impl LazyServiceWorkerRuntime {
         match &mut *state {
             LazyServiceWorkerRuntimeState::Deferred {
                 owner_wake_senders, ..
-            } => owner_wake_senders.push(sender),
+            } => owner_wake_senders.register(sender),
             LazyServiceWorkerRuntimeState::Live(service) => service.add_owner_wake_sender(sender),
         }
     }
@@ -647,5 +648,53 @@ impl RendererBrowserContextRuntime {
                     tag,
                 )
             })
+    }
+}
+
+#[cfg(test)]
+mod owner_wake_retirement_tests {
+    use super::*;
+
+    #[test]
+    fn deferred_worker_routes_are_bounded_without_service_initialization() {
+        let context = RendererBrowserContextRuntime::new();
+        let (peer_tx, _peer_rx) =
+            crate::service_worker_runtime::service_worker_owner_wake_channel();
+        context.add_service_worker_owner_wake_sender(peer_tx);
+        for _ in 0..64 {
+            let (sender, receiver) =
+                crate::service_worker_runtime::service_worker_owner_wake_channel();
+            context.add_service_worker_owner_wake_sender(sender);
+            {
+                let state = context.inner.service_worker_runtime.state.lock();
+                let LazyServiceWorkerRuntimeState::Deferred {
+                    owner_wake_senders, ..
+                } = &*state
+                else {
+                    panic!("wake registration must not initialize worker services");
+                };
+                assert_eq!(
+                    owner_wake_senders.len_for_test(),
+                    2,
+                    "only the peer and current renderer remain"
+                );
+            }
+            drop(receiver);
+        }
+        let (closed, receiver) = crate::service_worker_runtime::service_worker_owner_wake_channel();
+        drop(receiver);
+        context.add_service_worker_owner_wake_sender(closed);
+        let state = context.inner.service_worker_runtime.state.lock();
+        let LazyServiceWorkerRuntimeState::Deferred {
+            owner_wake_senders, ..
+        } = &*state
+        else {
+            unreachable!();
+        };
+        assert_eq!(
+            owner_wake_senders.len_for_test(),
+            1,
+            "closed admission must not reintroduce stale routes"
+        );
     }
 }

--- a/moli-renderer-v8/src/runtime/browser_context_runtime/shared_workers.rs
+++ b/moli-renderer-v8/src/runtime/browser_context_runtime/shared_workers.rs
@@ -1,7 +1,10 @@
 use crate::{
     RendererSyntheticResponseBody,
-    shared_worker_runtime::{SharedWorkerLaunchParams, SharedWorkerRuntimeOwnerWakeSender},
+    shared_worker_runtime::{
+        SharedWorkerLaunchParams, SharedWorkerRuntimeOwnerWake, SharedWorkerRuntimeOwnerWakeSender,
+    },
     worker::{WorkerPendingFetchContinue, WorkerPendingXhrContinue},
+    worker_owner_wake::WorkerOwnerWakeRoutes,
 };
 use moli_shared_worker::{
     SharedWorkerClientId, SharedWorkerClientOwnerId, SharedWorkerDescriptor, SharedWorkerInstanceId,
@@ -26,7 +29,7 @@ pub(super) struct LazySharedWorkerRuntime {
 
 enum LazySharedWorkerRuntimeState {
     Deferred {
-        owner_wake_senders: Vec<SharedWorkerRuntimeOwnerWakeSender>,
+        owner_wake_senders: WorkerOwnerWakeRoutes<SharedWorkerRuntimeOwnerWake>,
         owner_local_host_id: Option<RendererOwnerLocalHostId>,
     },
     Live(crate::shared_worker_runtime::SharedWorkerRuntimeService),
@@ -47,7 +50,7 @@ impl LazySharedWorkerRuntime {
     ) -> Self {
         Self {
             state: Mutex::new(LazySharedWorkerRuntimeState::Deferred {
-                owner_wake_senders: Vec::new(),
+                owner_wake_senders: WorkerOwnerWakeRoutes::default(),
                 owner_local_host_id: None,
             }),
             client_owner_id_allocator: Default::default(),
@@ -93,7 +96,7 @@ impl LazySharedWorkerRuntime {
             self.browser_context_runtime_id,
             self.output_transport.clone(),
         );
-        for sender in owner_wake_senders {
+        for sender in owner_wake_senders.into_senders() {
             service.add_owner_wake_sender(sender);
         }
         if let Some(owner_local_host_id) = owner_local_host_id {
@@ -124,7 +127,7 @@ impl LazySharedWorkerRuntime {
         match &mut *state {
             LazySharedWorkerRuntimeState::Deferred {
                 owner_wake_senders, ..
-            } => owner_wake_senders.push(sender),
+            } => owner_wake_senders.register(sender),
             LazySharedWorkerRuntimeState::Live(service) => service.add_owner_wake_sender(sender),
         }
     }
@@ -508,5 +511,52 @@ impl RendererBrowserContextRuntime {
             .is_some_and(|runtime| {
                 runtime.detach_runtime_inspector_session(instance_id, inspector_session_id)
             })
+    }
+}
+
+#[cfg(test)]
+mod owner_wake_retirement_tests {
+    use super::*;
+
+    #[test]
+    fn deferred_worker_routes_are_bounded_without_service_initialization() {
+        let context = RendererBrowserContextRuntime::new();
+        let (peer_tx, _peer_rx) = crate::shared_worker_runtime::shared_worker_owner_wake_channel();
+        context.add_shared_worker_owner_wake_sender(peer_tx);
+        for _ in 0..64 {
+            let (sender, receiver) =
+                crate::shared_worker_runtime::shared_worker_owner_wake_channel();
+            context.add_shared_worker_owner_wake_sender(sender);
+            {
+                let state = context.inner.shared_worker_runtime.state.lock();
+                let LazySharedWorkerRuntimeState::Deferred {
+                    owner_wake_senders, ..
+                } = &*state
+                else {
+                    panic!("wake registration must not initialize worker services");
+                };
+                assert_eq!(
+                    owner_wake_senders.len_for_test(),
+                    2,
+                    "only the peer and current renderer remain"
+                );
+            }
+            drop(receiver);
+        }
+        let (closed, receiver) = crate::shared_worker_runtime::shared_worker_owner_wake_channel();
+        drop(receiver);
+        context.add_shared_worker_owner_wake_sender(closed);
+        let state = context.inner.shared_worker_runtime.state.lock();
+        let LazySharedWorkerRuntimeState::Deferred {
+            owner_wake_senders, ..
+        } = &*state
+        else {
+            unreachable!();
+        };
+        assert_eq!(
+            owner_wake_senders.len_for_test(),
+            1,
+            "closed admission must not reintroduce stale routes"
+        );
     }
 }

--- a/moli-renderer-v8/src/service_worker_runtime/owner_wake.rs
+++ b/moli-renderer-v8/src/service_worker_runtime/owner_wake.rs
@@ -1,4 +1,3 @@
-use parking_lot::Mutex;
 use tokio::sync::mpsc;
 
 #[derive(Debug, Clone, Copy)]
@@ -6,43 +5,12 @@ pub(crate) enum ServiceWorkerRuntimeOwnerWake {
     ServiceLane,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct ServiceWorkerRuntimeOwnerWakeSender {
-    tx: mpsc::UnboundedSender<ServiceWorkerRuntimeOwnerWake>,
-}
-
-impl ServiceWorkerRuntimeOwnerWakeSender {
-    fn new(tx: mpsc::UnboundedSender<ServiceWorkerRuntimeOwnerWake>) -> Self {
-        Self { tx }
-    }
-
-    pub(super) fn signal(&self, wake: ServiceWorkerRuntimeOwnerWake) -> bool {
-        self.tx.send(wake).is_ok()
-    }
-}
-
-#[derive(Default)]
-pub(super) struct ServiceWorkerOwnerWake {
-    owner_wake_txs: Mutex<Vec<ServiceWorkerRuntimeOwnerWakeSender>>,
-}
-
-impl ServiceWorkerOwnerWake {
-    pub(super) fn add_owner_wake_sender(&self, sender: ServiceWorkerRuntimeOwnerWakeSender) {
-        self.owner_wake_txs.lock().push(sender);
-    }
-
-    pub(super) fn signal_service_lane_wake(&self) -> bool {
-        let mut senders = self.owner_wake_txs.lock();
-        let before = senders.len();
-        senders.retain(|sender| sender.signal(ServiceWorkerRuntimeOwnerWake::ServiceLane));
-        before > 0 && !senders.is_empty()
-    }
-}
+pub(crate) type ServiceWorkerRuntimeOwnerWakeSender =
+    mpsc::UnboundedSender<ServiceWorkerRuntimeOwnerWake>;
 
 pub(crate) fn service_worker_owner_wake_channel() -> (
     ServiceWorkerRuntimeOwnerWakeSender,
     mpsc::UnboundedReceiver<ServiceWorkerRuntimeOwnerWake>,
 ) {
-    let (tx, rx) = mpsc::unbounded_channel();
-    (ServiceWorkerRuntimeOwnerWakeSender::new(tx), rx)
+    mpsc::unbounded_channel()
 }

--- a/moli-renderer-v8/src/service_worker_runtime/service.rs
+++ b/moli-renderer-v8/src/service_worker_runtime/service.rs
@@ -338,14 +338,17 @@ impl ServiceWorkerRuntimeService {
     }
 
     pub(crate) fn add_owner_wake_sender(&self, sender: ServiceWorkerRuntimeOwnerWakeSender) {
-        self.inner.owner_wake.add_owner_wake_sender(sender.clone());
+        self.inner.owner_wake.lock().register(sender.clone());
         if self.pending_service_lane_event_count() > 0 {
-            sender.signal(ServiceWorkerRuntimeOwnerWake::ServiceLane);
+            let _ = sender.send(ServiceWorkerRuntimeOwnerWake::ServiceLane);
         }
     }
 
     pub(super) fn signal_service_lane_wake(&self) -> bool {
-        self.inner.owner_wake.signal_service_lane_wake()
+        self.inner
+            .owner_wake
+            .lock()
+            .broadcast(ServiceWorkerRuntimeOwnerWake::ServiceLane)
     }
 
     pub(crate) fn bind_target_output_transport(

--- a/moli-renderer-v8/src/service_worker_runtime/state.rs
+++ b/moli-renderer-v8/src/service_worker_runtime/state.rs
@@ -26,6 +26,7 @@ use crate::{
         ServiceWorkerWindowClientTarget,
     },
     worker::WorkerMessage,
+    worker_owner_wake::WorkerOwnerWakeRoutes,
 };
 
 use super::{
@@ -55,7 +56,7 @@ use super::{
         ServiceWorkerPendingMainScriptUpdateCheck, ServiceWorkerQueuedUnregisterJob,
         ServiceWorkerRegisterJob, ServiceWorkerRegistrationKey,
     },
-    owner_wake::ServiceWorkerOwnerWake,
+    owner_wake::ServiceWorkerRuntimeOwnerWake,
     registration::ServiceWorkerRegistration,
     resource_store::{ServiceWorkerStoredRegistration, SharedServiceWorkerResourceStore},
     run_owner::ServiceWorkerRunOwner,
@@ -131,7 +132,7 @@ pub(super) struct ServiceWorkerRuntimeInner {
     pub(super) pause_new_workers_on_start_for_devtools: AtomicBool,
     pub(super) state: Mutex<ServiceWorkerRuntimeState>,
     pub(super) service_lane: ServiceWorkerServiceLane,
-    pub(super) owner_wake: ServiceWorkerOwnerWake,
+    pub(super) owner_wake: Mutex<WorkerOwnerWakeRoutes<ServiceWorkerRuntimeOwnerWake>>,
     pub(super) resource_store: SharedServiceWorkerResourceStore,
     pub(super) restored_worker_context_runtime: RendererWorkerContextRuntime,
     pub(super) browser_resource_runtime: crate::network::BrowserResourceRuntimeBinding,
@@ -165,7 +166,7 @@ impl ServiceWorkerRuntimeInner {
                 output_transport,
             )),
             service_lane: ServiceWorkerServiceLane::default(),
-            owner_wake: ServiceWorkerOwnerWake::default(),
+            owner_wake: Mutex::default(),
             resource_store,
             restored_worker_context_runtime,
             browser_resource_runtime,

--- a/moli-renderer-v8/src/shared_worker_runtime/owner_wake.rs
+++ b/moli-renderer-v8/src/shared_worker_runtime/owner_wake.rs
@@ -1,4 +1,3 @@
-use parking_lot::Mutex;
 use tokio::sync::mpsc;
 
 #[derive(Debug, Clone, Copy)]
@@ -6,47 +5,12 @@ pub(crate) enum SharedWorkerRuntimeOwnerWake {
     ServiceLane,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct SharedWorkerRuntimeOwnerWakeSender {
-    tx: mpsc::UnboundedSender<SharedWorkerRuntimeOwnerWake>,
-}
-
-impl SharedWorkerRuntimeOwnerWakeSender {
-    fn new(tx: mpsc::UnboundedSender<SharedWorkerRuntimeOwnerWake>) -> Self {
-        Self { tx }
-    }
-
-    pub(super) fn signal(&self, wake: SharedWorkerRuntimeOwnerWake) -> bool {
-        self.tx.send(wake).is_ok()
-    }
-}
-
-#[derive(Default)]
-pub(super) struct SharedWorkerOwnerWake {
-    owner_wake_txs: Mutex<Vec<SharedWorkerRuntimeOwnerWakeSender>>,
-}
-
-impl SharedWorkerOwnerWake {
-    pub(super) fn add_owner_wake_sender(&self, sender: SharedWorkerRuntimeOwnerWakeSender) {
-        self.owner_wake_txs.lock().push(sender);
-    }
-
-    pub(super) fn signal_service_lane_wake(&self) -> bool {
-        self.signal_owner_wake(SharedWorkerRuntimeOwnerWake::ServiceLane)
-    }
-
-    fn signal_owner_wake(&self, wake: SharedWorkerRuntimeOwnerWake) -> bool {
-        let mut senders = self.owner_wake_txs.lock();
-        let before = senders.len();
-        senders.retain(|sender| sender.signal(wake));
-        before > 0 && !senders.is_empty()
-    }
-}
+pub(crate) type SharedWorkerRuntimeOwnerWakeSender =
+    mpsc::UnboundedSender<SharedWorkerRuntimeOwnerWake>;
 
 pub(crate) fn shared_worker_owner_wake_channel() -> (
     SharedWorkerRuntimeOwnerWakeSender,
     mpsc::UnboundedReceiver<SharedWorkerRuntimeOwnerWake>,
 ) {
-    let (tx, rx) = mpsc::unbounded_channel();
-    (SharedWorkerRuntimeOwnerWakeSender::new(tx), rx)
+    mpsc::unbounded_channel()
 }

--- a/moli-renderer-v8/src/shared_worker_runtime/service.rs
+++ b/moli-renderer-v8/src/shared_worker_runtime/service.rs
@@ -12,15 +12,13 @@ use moli_shared_worker::{
 use parking_lot::Mutex;
 use tracing::trace;
 
-use crate::runtime::RendererOwnerLocalHostId;
+use crate::{runtime::RendererOwnerLocalHostId, worker_owner_wake::WorkerOwnerWakeRoutes};
 
 use super::{
     host::SharedRendererSharedWorkerHost,
     instances::SharedWorkerHostStore,
     matching::{SharedWorkerClientOwnerIdAllocator, SharedWorkerMatchingStore},
-    owner_wake::{
-        SharedWorkerOwnerWake, SharedWorkerRuntimeOwnerWake, SharedWorkerRuntimeOwnerWakeSender,
-    },
+    owner_wake::{SharedWorkerRuntimeOwnerWake, SharedWorkerRuntimeOwnerWakeSender},
     service_lane::SharedWorkerServiceLane,
     target_output_streams::SharedWorkerTargetOutputStreams,
 };
@@ -53,7 +51,7 @@ struct SharedWorkerRuntimeInner {
     matching: Arc<SharedWorkerMatchingStore>,
     hosts: Arc<SharedWorkerHostStore>,
     service_lane: Arc<SharedWorkerServiceLane>,
-    owner_wake: SharedWorkerOwnerWake,
+    owner_wake: Mutex<WorkerOwnerWakeRoutes<SharedWorkerRuntimeOwnerWake>>,
     owner_local_host_id: Mutex<Option<RendererOwnerLocalHostId>>,
     target_output_streams: OnceLock<SharedWorkerTargetOutputStreams>,
 }
@@ -126,9 +124,9 @@ impl SharedWorkerRuntimeService {
     }
 
     pub(crate) fn add_owner_wake_sender(&self, sender: SharedWorkerRuntimeOwnerWakeSender) {
-        self.inner.owner_wake.add_owner_wake_sender(sender.clone());
+        self.inner.owner_wake.lock().register(sender.clone());
         if self.pending_service_lane_event_count() > 0 {
-            sender.signal(SharedWorkerRuntimeOwnerWake::ServiceLane);
+            let _ = sender.send(SharedWorkerRuntimeOwnerWake::ServiceLane);
         }
     }
 
@@ -146,7 +144,10 @@ impl SharedWorkerRuntimeService {
     }
 
     pub(super) fn signal_service_lane_wake(&self) -> bool {
-        self.inner.owner_wake.signal_service_lane_wake()
+        self.inner
+            .owner_wake
+            .lock()
+            .broadcast(SharedWorkerRuntimeOwnerWake::ServiceLane)
     }
 
     #[cfg(test)]

--- a/moli-renderer-v8/src/worker_owner_wake.rs
+++ b/moli-renderer-v8/src/worker_owner_wake.rs
@@ -1,0 +1,127 @@
+//! Wake-route storage shared by deferred and live browser-context workers.
+//!
+//! This collection owns only channel senders, not renderer lifecycle authority.
+//! Callers provide synchronization: the lazy runtime's state lock while deferred,
+//! and the service's wake-route lock while live.
+
+use tokio::sync::mpsc;
+
+pub(crate) struct WorkerOwnerWakeRoutes<W> {
+    senders: Vec<mpsc::UnboundedSender<W>>,
+}
+
+impl<W> Default for WorkerOwnerWakeRoutes<W> {
+    fn default() -> Self {
+        Self {
+            senders: Vec::new(),
+        }
+    }
+}
+
+impl<W> WorkerOwnerWakeRoutes<W> {
+    pub(crate) fn register(&mut self, sender: mpsc::UnboundedSender<W>) {
+        // Deferred or idle services may never send another wake. Prune on
+        // registration too, so sequential target churn cannot accumulate closed
+        // channels. This is not immediate unregistration: the last closed routes
+        // remain until the next register/broadcast, and Vec capacity is retained.
+        // Tokio's receiver-drop waker cleanup independently releases the retired
+        // renderer's I/O driver even while these senders remain registered.
+        self.senders.retain(|registered| !registered.is_closed());
+        if !sender.is_closed() {
+            self.senders.push(sender);
+        }
+    }
+
+    /// Transfer deferred routes through the live service's registration entry
+    /// point, which also wakes the new owner if service-lane work is pending.
+    pub(crate) fn into_senders(self) -> impl Iterator<Item = mpsc::UnboundedSender<W>> {
+        self.senders.into_iter()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len_for_test(&self) -> usize {
+        self.senders.len()
+    }
+}
+
+impl<W: Copy> WorkerOwnerWakeRoutes<W> {
+    /// Returns whether at least one receiver accepted the wake.
+    pub(crate) fn broadcast(&mut self, wake: W) -> bool {
+        self.senders.retain(|sender| sender.send(wake).is_ok());
+        !self.senders.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registration_prunes_closed_routes_without_affecting_live_peer() {
+        let mut routes = WorkerOwnerWakeRoutes::default();
+        let (peer, mut peer_rx) = mpsc::unbounded_channel();
+        routes.register(peer);
+        for _ in 0..64 {
+            let (sender, receiver) = mpsc::unbounded_channel();
+            routes.register(sender);
+            assert_eq!(routes.senders.len(), 2);
+            drop(receiver);
+        }
+        let (closed, mut receiver) = mpsc::unbounded_channel();
+        receiver.close();
+        routes.register(closed);
+        assert_eq!(routes.senders.len(), 1);
+        assert!(routes.broadcast(7));
+        assert_eq!(peer_rx.try_recv(), Ok(7));
+        assert!(matches!(
+            peer_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
+    fn broadcast_wakes_every_live_receiver_and_prunes_retired_routes() {
+        let mut routes = WorkerOwnerWakeRoutes::default();
+        assert!(!routes.broadcast(1));
+        let (first, mut first_rx) = mpsc::unbounded_channel();
+        let (retired, retired_rx) = mpsc::unbounded_channel();
+        let (second, mut second_rx) = mpsc::unbounded_channel();
+        routes.register(first);
+        routes.register(retired);
+        routes.register(second);
+        drop(retired_rx);
+        assert!(routes.broadcast(7));
+        assert_eq!(routes.senders.len(), 2);
+        assert!(routes.broadcast(9));
+        for receiver in [&mut first_rx, &mut second_rx] {
+            assert_eq!(receiver.try_recv(), Ok(7));
+            assert_eq!(receiver.try_recv(), Ok(9));
+            assert!(matches!(
+                receiver.try_recv(),
+                Err(mpsc::error::TryRecvError::Empty)
+            ));
+        }
+        drop(first_rx);
+        drop(second_rx);
+        assert!(!routes.broadcast(11));
+        assert!(routes.senders.is_empty());
+    }
+
+    #[test]
+    fn transfer_preserves_live_routes_without_reviving_closed_receivers() {
+        let mut deferred = WorkerOwnerWakeRoutes::default();
+        let (peer, mut peer_rx) = mpsc::unbounded_channel();
+        let (retired, retired_rx) = mpsc::unbounded_channel();
+        deferred.register(peer);
+        deferred.register(retired);
+        drop(retired_rx);
+
+        let mut live = WorkerOwnerWakeRoutes::default();
+        for sender in deferred.into_senders() {
+            live.register(sender);
+        }
+        assert_eq!(live.senders.len(), 1);
+        assert!(live.broadcast(7));
+        assert_eq!(peer_rx.try_recv(), Ok(7));
+    }
+}


### PR DESCRIPTION
Use one typed wake-route collection for deferred and live SharedWorker and ServiceWorker services. Prune closed channels on registration and broadcast so idle services do not accumulate metadata with cumulative target churn.

Keep existing synchronization and route deferred handoff through live registration to preserve pending-work wakes. Cover pruning, fanout, handoff, and lazy runtime integration.