### PR TITLE
fix(dom): include CDATA in child text content

### DIFF
--- a/moli-core/tests/scripts.rs
+++ b/moli-core/tests/scripts.rs
@@ -1,3 +1,6 @@
+#[path = "scripts/child_script_text.rs"]
+mod child_script_text;
+
 use moli_test_support as support;
 
 use anyhow::Result;

--- a/moli-core/tests/scripts/child_script_text.rs
+++ b/moli-core/tests/scripts/child_script_text.rs
@@ -1,0 +1,99 @@
+use super::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn child_text_idl_getters_include_cdata_but_not_nested_elements() -> Result<()> {
+    let server = FixtureServer::spawn().await?;
+    let browser = Browser::new(AppConfig::default())?;
+    let mut page = browser.fetch(&server.url("/static")).await?;
+    let result = page.evaluate_runtime_expression_with_await_async(
+        r#"(() => {
+          const xml = document.implementation.createDocument(null, 'root');
+          return JSON.stringify([['script', 'text'], ['title', 'text'], ['textarea', 'defaultValue']].map(([tag, property]) => {
+            const el = document.createElement(tag);
+            const cdata = xml.createCDATASection('CDATA 🦀');
+            const nested = document.createElement('span');
+            nested.textContent = 'ignored descendant';
+            el.append(document.createTextNode('leading '), cdata,
+              document.createComment('ignored comment'),
+              document.createProcessingInstruction('probe', 'ignored instruction'), nested,
+              document.createTextNode(' trailing'));
+            const initial = el[property], recursive = el.textContent;
+            el.normalize();
+            const normalized = el[property], cdataPreserved = cdata.parentNode === el && cdata.nodeType === 4;
+            cdata.replaceData(0, cdata.length, 'changed');
+            const changed = el[property];
+            cdata.remove();
+            return {tag, initial, recursive, normalized, cdataPreserved, changed, removed: el[property]};
+          }));
+        })()"#, true,
+    ).await?;
+    server.shutdown().await;
+    let result: serde_json::Value =
+        serde_json::from_str(result["value"].as_str().expect("child text getters"))?;
+    assert_eq!(
+        result,
+        serde_json::json!(
+            ["script", "title", "textarea"].map(|tag| serde_json::json!({
+                "tag": tag, "initial": "leading CDATA 🦀 trailing",
+                "recursive": "leading CDATA 🦀ignored descendant trailing",
+                "normalized": "leading CDATA 🦀 trailing", "cdataPreserved": true,
+                "changed": "leading changed trailing", "removed": "leading  trailing"
+            }))
+        )
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn xml_child_parser_executes_mixed_text_and_cdata_script_source() -> Result<()> {
+    let server = FixtureServer::spawn().await?;
+    let browser = Browser::new(AppConfig::default())?;
+    let mut page = browser.fetch(&server.url("/static")).await?;
+    let result = page
+        .evaluate_runtime_expression_with_await_async(
+            r#"(async () => {
+          const results = [];
+          for (const type of ['application/xhtml+xml', 'application/xml', 'image/svg+xml']) {
+            const svg = type === 'image/svg+xml';
+            const start = svg ? '<svg xmlns="http://www.w3.org/2000/svg">' :
+              '<html xmlns="http://www.w3.org/1999/xhtml"><head/><body>';
+            const end = svg ? '</svg>' : '</body></html>';
+            const markup = start + '<script>' +
+              '<![CDATA[window.cdataSteps = ["first"];]]>' +
+              '<![CDATA[cdataSteps.push("second");]]>' +
+              '<ignored>throw new Error("must not execute descendants")</ignored>' +
+              'cdataSteps.push("third");' + '<' + '/script>' +
+              '<script>window.afterCdata = typeof cdataSteps;' + '<' + '/script>' + end;
+            const frame = await new Promise(resolve => {
+              const frame = document.createElement('iframe');
+              frame.onload = () => resolve(frame);
+              frame.src = '/compat/child-dynamic-markup-document?type=' + encodeURIComponent(type) +
+                '&markup=' + encodeURIComponent(markup);
+              document.body.append(frame);
+            });
+            results.push({type, contentType: frame.contentDocument.contentType,
+              steps: frame.contentWindow.cdataSteps, after: frame.contentWindow.afterCdata,
+              readyState: frame.contentDocument.readyState});
+            frame.remove();
+          }
+          return JSON.stringify(results);
+        })()"#,
+            true,
+        )
+        .await?;
+    server.shutdown().await;
+    let result: serde_json::Value =
+        serde_json::from_str(result["value"].as_str().expect("XML script text"))?;
+    assert_eq!(
+        result,
+        serde_json::json!(
+            ["application/xhtml+xml", "application/xml", "image/svg+xml"].map(
+                |mime| serde_json::json!({
+                    "type": mime, "contentType": mime, "steps": ["first", "second", "third"],
+                    "after": "object", "readyState": "complete"
+                })
+            )
+        )
+    );
+    Ok(())
+}

--- a/moli-dom/src/native/node/mod.rs
+++ b/moli-dom/src/native/node/mod.rs
@@ -502,9 +502,14 @@ impl Node {
 
     pub fn direct_text_content(&self, dom: &NativeDom) -> String {
         self.child_ids(dom)
-            .filter_map(|child_id| dom.node(child_id).and_then(Node::as_text))
-            .fold(String::new(), |mut out, text| {
-                out.push_str(text.data());
+            .filter_map(|child_id| match dom.node(child_id)?.data() {
+                NodeData::Text(text) => Some(text.data()),
+                // CDATASection implements Text, including for child text content.
+                NodeData::CDataSection(cdata) => Some(cdata.data()),
+                _ => None,
+            })
+            .fold(String::new(), |mut out, data| {
+                out.push_str(data);
                 out
             })
     }

--- a/moli-dom/src/native/scripts.rs
+++ b/moli-dom/src/native/scripts.rs
@@ -57,17 +57,92 @@ impl NativeDom {
             return None;
         }
 
-        let mut script_text = String::new();
-        for child_id in script_node.child_ids(self) {
-            let Some(child) = self.node(child_id) else {
-                continue;
-            };
-
-            if let Some(text) = child.as_text() {
-                script_text.push_str(text.data());
-            }
-        }
-
+        let script_text = script_node.direct_text_content(self);
         (!script_text.is_empty()).then_some(script_text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::DomHost;
+
+    fn mixed_text_children(dom: &mut NativeDom, parent: NativeNodeId) -> NativeNodeId {
+        let leading = dom.create_text_node("leading ");
+        let cdata = dom.create_cdata_section("CDATA 🦀");
+        let comment = dom.create_comment("ignored comment");
+        let instruction = dom.create_processing_instruction("probe", "ignored instruction");
+        let nested = dom.create_element("span");
+        let nested_text = dom.create_text_node("ignored descendant");
+        let trailing = dom.create_text_node(" trailing");
+        assert!(dom.append_child(nested, nested_text));
+        for child in [leading, cdata, comment, instruction, nested, trailing] {
+            assert!(dom.append_child(parent, child));
+        }
+        cdata
+    }
+
+    #[test]
+    fn child_text_content_includes_cdata_in_order_but_not_descendant_text() {
+        let mut dom = NativeDom::new_xml(url::Url::parse("https://child-text.test/").unwrap());
+        let parent = dom.create_element("div");
+        let cdata = mixed_text_children(&mut dom, parent);
+        assert_eq!(
+            dom.direct_text_content(parent).as_deref(),
+            Some("leading CDATA 🦀 trailing")
+        );
+        assert_eq!(
+            dom.text_content(parent).as_deref(),
+            Some("leading CDATA 🦀ignored descendant trailing")
+        );
+        assert!(dom.remove_child(parent, cdata));
+        assert_eq!(
+            dom.direct_text_content(parent).as_deref(),
+            Some("leading  trailing")
+        );
+        assert!(dom.append_child(parent, cdata));
+        assert_eq!(
+            dom.direct_text_content(parent).as_deref(),
+            Some("leading  trailingCDATA 🦀")
+        );
+    }
+
+    #[test]
+    fn script_text_includes_cdata_for_html_and_svg_and_preserves_empty_result() {
+        let mut dom = NativeDom::new_xml(url::Url::parse("https://script-text.test/").unwrap());
+        for namespace in ["http://www.w3.org/1999/xhtml", "http://www.w3.org/2000/svg"] {
+            let script = dom.create_element_ns(Some(namespace), "script").unwrap();
+            assert_eq!(dom.script_text(script), None);
+            let empty = dom.create_cdata_section("");
+            assert!(dom.append_child(script, empty));
+            assert_eq!(dom.script_text(script), None);
+            mixed_text_children(&mut dom, script);
+            assert_eq!(
+                dom.script_text(script).as_deref(),
+                Some("leading CDATA 🦀 trailing")
+            );
+        }
+        let non_script = dom.create_element("div");
+        mixed_text_children(&mut dom, non_script);
+        assert_eq!(dom.script_text(non_script), None);
+    }
+
+    #[test]
+    fn parser_script_internal_text_includes_direct_cdata() {
+        let mut dom = NativeDom::new_xml(url::Url::parse("https://script-slot.test/").unwrap());
+        let script = dom
+            .create_element_ns(Some("http://www.w3.org/1999/xhtml"), "script")
+            .unwrap();
+        mixed_text_children(&mut dom, script);
+        let mut host = DomHost::from_dom(dom);
+        assert!(host.finish_parsing_script_children(script));
+        assert_eq!(
+            host.node(script)
+                .unwrap()
+                .as_element()
+                .unwrap()
+                .script_text_internal_slot(),
+            "leading CDATA 🦀 trailing"
+        );
     }
 }

--- a/moli-test-support/src/routes_core.rs
+++ b/moli-test-support/src/routes_core.rs
@@ -149,6 +149,23 @@ pub(super) async fn static_page() -> Html<&'static str> {
     Html(STATIC_HTML)
 }
 
+pub(super) async fn child_dynamic_markup_document(
+    Query(params): Query<HashMap<String, String>>,
+) -> Response {
+    let content_type = match params.get("type").map(String::as_str) {
+        Some("text/xml") => "text/xml",
+        Some("application/xml") => "application/xml",
+        Some("application/xhtml+xml") => "application/xhtml+xml",
+        Some("image/svg+xml") => "image/svg+xml",
+        _ => "text/html",
+    };
+    (
+        [(CONTENT_TYPE, content_type)],
+        params.get("markup").cloned().unwrap_or_default(),
+    )
+        .into_response()
+}
+
 pub(super) async fn future_interval_done_page() -> Html<&'static str> {
     Html(FUTURE_INTERVAL_DONE_HTML)
 }

--- a/moli-test-support/src/server_routes.rs
+++ b/moli-test-support/src/server_routes.rs
@@ -3,6 +3,10 @@ use super::*;
 pub(super) fn build_router() -> Router {
     routes_wait::add_wait_routes(Router::new())
         .route("/static", get(static_page))
+        .route(
+            "/compat/child-dynamic-markup-document",
+            get(child_dynamic_markup_document),
+        )
         .route("/runtime/future-interval-done", get(future_interval_done_page))
         .route("/encoding/gbk-meta", get(encoding_gbk_meta_page))
         .route(


### PR DESCRIPTION
Extract an independently mergeable topic from wpt-misc-fix at a70a96f9d1e0573cc9721275fc03b78e4c35d3f1.

Register the child text content regression module without including later script test modules. Include the XML document fixture route used by the CDATA regression so this branch does not depend on the separate XML input-stream changes.

Source commits:
- 7f587e1251e60a24df517cf88c602851c58e3f08
- ae3a3f1096ba82164f98b359a7f734d0b667a680

Validation:
- cargo fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo nextest run --no-fail-fast