### PR TITLE
fix(modules): decode fetched source as UTF-8

### DIFF
--- a/moli-encoding/src/lib.rs
+++ b/moli-encoding/src/lib.rs
@@ -22,7 +22,7 @@ pub use labels::{
 };
 pub use legacy_text::decode_text_for_legacy_web;
 pub use query::encode_url_query_for_legacy_web;
-pub use script::decode_classic_script_source;
+pub use script::{decode_classic_script_source, decode_utf8};
 
 #[cfg(test)]
 mod tests;

--- a/moli-encoding/src/script.rs
+++ b/moli-encoding/src/script.rs
@@ -2,6 +2,13 @@ use encoding_rs::Encoding;
 
 use crate::{encoding_for_label, encoding_from_response_headers};
 
+pub fn decode_utf8(bytes: &[u8]) -> String {
+    encoding_rs::UTF_8
+        .decode_with_bom_removal(bytes)
+        .0
+        .into_owned()
+}
+
 pub fn decode_classic_script_source(
     bytes: &[u8],
     headers: &[(String, String)],

--- a/moli-encoding/src/tests.rs
+++ b/moli-encoding/src/tests.rs
@@ -483,6 +483,12 @@ fn classic_script_bom_wins_over_labels() {
 }
 
 #[test]
+fn utf8_decode_removes_only_a_utf8_bom() {
+    assert_eq!(decode_utf8(b"\xef\xbb\xbfdiv {}"), "div {}");
+    assert_eq!(decode_utf8(b"\xff\xfed\0i\0v\0"), "��d\0i\0v\0");
+}
+
+#[test]
 fn url_query_encoder_uses_selected_legacy_encoding() {
     let encoded =
         encode_url_query_for_legacy_web("/search?q=家居&safe=a+b%20c#frag", encoding_rs::GBK);

--- a/moli-renderer-v8/src/module_runtime/graph.rs
+++ b/moli-renderer-v8/src/module_runtime/graph.rs
@@ -467,7 +467,7 @@ impl NativeModuleGraphFetchRequest {
                         crate::referrer_policy::response_referrer_policy_from_headers(
                             &response.headers,
                         );
-                    let (head, body, body_bytes) = response.into_parts();
+                    let (head, _body, body_bytes) = response.into_parts();
                     Ok(match kind {
                         ModuleKind::WebAssembly => ModuleGraphFetchedSource::new(
                             head.final_url,
@@ -481,7 +481,7 @@ impl NativeModuleGraphFetchRequest {
                         | ModuleKind::ModulePreloadText => ModuleGraphFetchedSource::new(
                             head.final_url,
                             head.redirected,
-                            ModuleSource::text(body),
+                            ModuleSource::text(moli_encoding::decode_utf8(&body_bytes)),
                         )
                         .with_response_referrer_policy(response_referrer_policy),
                     })

--- a/moli-renderer-v8/src/worker/thread/mod.rs
+++ b/moli-renderer-v8/src/worker/thread/mod.rs
@@ -755,7 +755,7 @@ fn start_worker_module_graph_fetch(
                     .elapsed()
                     .as_millis()
                     .min(u64::MAX as u128) as u64;
-                let (head, body, body_bytes) = response.into_parts();
+                let (head, _body, body_bytes) = response.into_parts();
                 let response_referrer_policy =
                     crate::referrer_policy::response_referrer_policy_from_headers(&head.headers);
                 let resource = WorkerScriptResource::from_response_parts(
@@ -769,7 +769,7 @@ fn start_worker_module_graph_fetch(
                 let source = if requested_kind == WorkerModuleKind::WebAssembly {
                     WorkerModuleSource::binary(body_bytes)
                 } else {
-                    WorkerModuleSource::text(body)
+                    WorkerModuleSource::text(moli_encoding::decode_utf8(&body_bytes))
                 };
                 Ok(WorkerModuleFetchedSource::new(final_url, source)
                     .with_resource(resource)


### PR DESCRIPTION
Extract an independently mergeable topic from wpt-misc-fix at a70a96f9d1e0573cc9721275fc03b78e4c35d3f1.

Apply UTF-8 decoding directly to the baseline module fetch path without including import-map integrity changes.

Source commits:
- bffc90964df3b3ee6e3cd929ac8a19efaaf83a54

Validation:
- cargo fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo nextest run --no-fail-fast